### PR TITLE
fix duplicate excel sheetname in community profiles

### DIFF
--- a/src/components/field/DownloadAllChartsButton.jsx
+++ b/src/components/field/DownloadAllChartsButton.jsx
@@ -163,6 +163,8 @@ export default function DownloadAllChartsButton({ muni }) {
       });
     });
 
+    const usedSheetNames = new Set();
+    
     Object.entries(data).forEach(([tableName, tableData]) => {
       if (tableData && tableData.length > 0) {
         // Create worksheet with municipality header
@@ -175,6 +177,18 @@ export default function DownloadAllChartsButton({ muni }) {
         // Excel has 31 char limit
         let sheetName =
           tableMapping[tableName]?.slice(0, 31) || tableName.slice(0, 31);
+        
+        // Ensure unique sheet names
+        let counter = 1;
+        let originalSheetName = sheetName;
+        while (usedSheetNames.has(sheetName)) {
+          const suffix = `_${counter}`;
+          const maxLength = 31 - suffix.length;
+          sheetName = originalSheetName.slice(0, maxLength) + suffix;
+          counter++;
+        }
+        usedSheetNames.add(sheetName);
+        
         XLSX.utils.book_append_sheet(wb, ws, sheetName);
       }
     });


### PR DESCRIPTION
- Tracks used sheet names: Creates a Set called usedSheetNames to keep track of all worksheet names that have already been used.

- Checks for duplicates: Before creating each worksheet, it checks if the proposed sheet name already exists in the set.

- Generates unique names: If a duplicate is found, it appends a counter suffix (e.g., _1, _2, etc.) to make the name unique while still respecting Excel's 31-character limit.

- Adds to tracking set: Once a unique name is found, it's added to the usedSheetNames set to prevent future conflicts.