### PR TITLE
Fix print charts to include all categories and optimize data loading

### DIFF
--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -16,6 +16,7 @@ import PieChart from "../containers/visualizations/PieChart";
 import LineChart from "../containers/visualizations/LineChart";
 import DownloadAllChartsButton from "./field/DownloadAllChartsButton";
 import DataTableModal from "./field/DataTableModal";
+import { store } from "../store";
 
 const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
   const dispatch = useDispatch();
@@ -54,19 +55,40 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
   }, [activeTab, muni, dispatch]);
 
   const handlePrintCharts = async () => {
-    // Load all chart data from all categories before printing
-    const fetchPromises = [];
+    // Check if all chart data is already loaded
+    const state = store.getState();
+    const allTables = [];
     
+    // Get all table names from charts
     Object.values(charts).forEach((category) => {
       Object.values(category).forEach((chartInfo) => {
-        fetchPromises.push(
-          dispatch(fetchChartData({ chartInfo: chartInfo, municipality: muni }))
-        );
+        Object.keys(chartInfo.tables).forEach((tableName) => {
+          allTables.push(tableName);
+        });
       });
     });
 
-    // Wait for all data to be loaded
-    await Promise.all(fetchPromises);
+    // Check if all data is already available
+    const allDataLoaded = allTables.every((tableName) => {
+      const data = state.chart.cache[tableName]?.[muni];
+      return data && data.length > 0;
+    });
+
+    // Only fetch data if not all data is loaded
+    if (!allDataLoaded) {
+      const fetchPromises = [];
+      
+      Object.values(charts).forEach((category) => {
+        Object.values(category).forEach((chartInfo) => {
+          fetchPromises.push(
+            dispatch(fetchChartData({ chartInfo: chartInfo, municipality: muni }))
+          );
+        });
+      });
+
+      // Wait for all data to be loaded
+      await Promise.all(fetchPromises);
+    }
     
     // Add print-specific CSS to show all tabs for printing
     const printStyle = document.createElement('style');

--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -53,6 +53,76 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
     }
   }, [activeTab, muni, dispatch]);
 
+  const handlePrintCharts = async () => {
+    // Load all chart data from all categories before printing
+    const fetchPromises = [];
+    
+    Object.values(charts).forEach((category) => {
+      Object.values(category).forEach((chartInfo) => {
+        fetchPromises.push(
+          dispatch(fetchChartData({ chartInfo: chartInfo, municipality: muni }))
+        );
+      });
+    });
+
+    // Wait for all data to be loaded
+    await Promise.all(fetchPromises);
+    
+    // Add print-specific CSS to show all tabs for printing
+    const printStyle = document.createElement('style');
+    printStyle.textContent = `
+      @media print {
+        .tab {
+          display: block !important;
+        }
+        .tab:not(.active) {
+          display: block !important;
+        }
+        .tabs {
+          display: none !important;
+        }
+        .dropdown-wrapper {
+          display: none !important;
+        }
+        .button-group {
+          display: none !important;
+        }
+        .chart-wrapper .button-group {
+          display: none !important;
+        }
+        .chart-wrapper button {
+          display: none !important;
+        }
+        .chart-wrapper a {
+          display: none !important;
+        }
+        .tab__row {
+          display: flex !important;
+          flex-wrap: wrap !important;
+        }
+        .tab__row .chart-wrapper {
+          width: 50% !important;
+          box-sizing: border-box !important;
+          padding: 0 10px !important;
+        }
+        .chart-wrapper svg {
+          width: 100% !important;
+          height: auto !important;
+        }
+      }
+    `;
+    document.head.appendChild(printStyle);
+    
+    // Small delay to ensure charts are rendered with data
+    setTimeout(() => {
+      window.print();
+      // Clean up the print style after printing
+      setTimeout(() => {
+        document.head.removeChild(printStyle);
+      }, 1000);
+    }, 500);
+  };
+
   return (
     <article className="component CommunityProfiles">
       <div className="page-header">
@@ -70,7 +140,7 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
             <div className="description-wrapper">
               <p className="description">{descriptions[muniSlug.toLowerCase()] || "No description available."}</p>
               <div className="button-group">
-                <button onClick={() => window.print()} type="button" className="print-button">
+                <button onClick={handlePrintCharts} type="button" className="print-button">
                   Print charts
                 </button>
                 <DownloadAllChartsButton muni={muni} />

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -1243,7 +1243,6 @@ SELECT CONCAT(MIN(cal_year), '-', MAX(cal_year)) AS latest_year FROM years;`;
           return [];
         }
         const row = commData[0];
-        console.log(row)
         return Object.keys(chart.labels).map((key) => ({
           value: row[key],
           label: chart.labels[key],

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -23,151 +23,176 @@ class DataViewerClass extends React.Component {
     };
     this.updateSelectedYears = this.updateSelectedYears.bind(this);
     this.updatePage = this.updatePage.bind(this);
+    this.loadDatasetData = this.loadDatasetData.bind(this);
+    this.hasLoaded = false; // Flag to prevent duplicate API calls in StrictMode
   }
 
   componentDidMount() {
-    this.props.fetchDatasets().then(() => {
-      const dataset = this.props.datasets.filter((datasetObj) => +datasetObj.seq_id === +this.props.params.id)[0];
-      let headerQuery;
-      if (!dataset) {
-        this.setState({ loading: false, error: "Dataset not found" });
-        return;
-      }
+    // Prevent duplicate API calls in React.StrictMode
+    if (this.hasLoaded) {
+      return;
+    }
+    this.hasLoaded = true;
 
-      const tableQuery = axios.get(
-        `/api?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}${dataset.yearcolumn ? `&orderByColumn=${dataset.yearcolumn}&orderByDirection=DESC` : ""}&limit=500000`,
+    // Check if datasets are already loaded, if not fetch them
+    if (this.props.datasets.length === 0) {
+      this.props.fetchDatasets().then(() => {
+        this.loadDatasetData();
+      });
+    } else {
+      this.loadDatasetData();
+    }
+  }
+
+  loadDatasetData() {
+    const dataset = this.props.datasets.filter((datasetObj) => +datasetObj.seq_id === +this.props.params.id)[0];
+    let headerQuery;
+    if (!dataset) {
+      this.setState({ loading: false, error: "Dataset not found" });
+      return;
+    }
+    let limit = 15000;
+    if (dataset.table_name === "econ_es202_naics_4d_m" || dataset.table_name === "econ_es202_naics_2d_m" || dataset.table_name === "econ_es202_naics_3d_m") {
+      limit = 460000 ;
+    }
+    const tableQuery = axios.get(
+      `/api?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}${dataset.yearcolumn ? `&orderByColumn=${dataset.yearcolumn}&orderByDirection=DESC` : ""}&limit=15000`,
+    );
+
+    if (dataset.db_name === "gisdata" || dataset.db_name === "towndata") {
+      headerQuery = axios.get(
+        `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}`,
       );
+    } else {
+      headerQuery = axios.get(
+        `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}`,
+      );
+    }
 
-      if (dataset.db_name === "gisdata" || dataset.db_name === "towndata") {
-        headerQuery = axios.get(
-          `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}`,
+    if (dataset.schemaname === "tabular") {
+      if (dataset.yearcolumn) {
+        const yearQuery = axios.get(
+          `/api/?token=${import.meta.env.VITE_MAPC_API_TOKEN}&distinctColumn=${dataset.yearcolumn}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}&limit=50`,
         );
-      } else {
-        headerQuery = axios.get(
-          `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}`,
-        );
-      }
-
-      if (dataset.schemaname === "tabular") {
-        if (dataset.yearcolumn) {
-          const yearQuery = axios.get(
-            `/api/?token=${import.meta.env.VITE_MAPC_API_TOKEN}&distinctColumn=${dataset.yearcolumn}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}&limit=50`,
-          );
-          axios
-            .all([yearQuery, tableQuery, headerQuery])
-            .then((response) => {
-              const yearResults = response[0];
-              const tableResults = response[1];
-              const metadata = Object.values(response[2].data)[0];
-              // Validate metadata structure
-              const universeData = metadata.find((row) => row.name === "universe");
-              const descriptionData = metadata.find((row) => row.name === "descriptn");
-              this.setState({
-                availableYears: yearResults.data.rows
+        axios
+          .all([yearQuery, tableQuery, headerQuery])
+          .then((response) => {
+            const yearResults = response[0];
+            const tableResults = response[1];
+            const metadata = Object.values(response[2].data)[0];
+            // Validate metadata structure
+            const universeData = metadata.find((row) => row.name === "universe");
+            const descriptionData = metadata.find((row) => row.name === "descriptn");
+            this.setState({
+              availableYears: yearResults.data.rows
+                .map((year) => Object.values(year)[0])
+                .sort()
+                .reverse(),
+              rows: tableResults.data.rows,
+              universe: universeData ? universeData.details : "",
+              description: descriptionData ? descriptionData.details : "",
+              columnKeys: metadata
+                .filter((object) => tableResults.data.rows[0] && Object.keys(tableResults.data.rows[0]).includes(object.name))
+                .filter((header) => header.name !== "seq_id"),
+              metadata,
+              selectedYears: [
+                yearResults.data.rows
                   .map((year) => Object.values(year)[0])
                   .sort()
-                  .reverse(),
-                rows: tableResults.data.rows,
-                universe: universeData ? universeData.details : "",
-                description: descriptionData ? descriptionData.details : "",
-                columnKeys: metadata
-                  .filter((object) => tableResults.data.rows[0] && Object.keys(tableResults.data.rows[0]).includes(object.name))
-                  .filter((header) => header.name !== "seq_id"),
-                metadata,
-                selectedYears: [
-                  yearResults.data.rows
-                    .map((year) => Object.values(year)[0])
-                    .sort()
-                    .reverse()[0],
-                ],
-                table: dataset.table_name,
-                schema: dataset.schemaname,
-                database: dataset.db_name,
-                title: dataset.menu3,
-                source: dataset.source,
-                queryYearColumn: dataset.yearcolumn,
-                loading: false,
-              });
-            })
-            .catch((error) => {
-              this.setState({ loading: false, error: "Error loading dataset" });
-              console.error("Error:", error);
+                  .reverse()[0],
+              ],
+              table: dataset.table_name,
+              schema: dataset.schemaname,
+              database: dataset.db_name,
+              title: dataset.menu3,
+              source: dataset.source,
+              queryYearColumn: dataset.yearcolumn,
+              loading: false,
             });
-        } else {
-          axios
-            .all([tableQuery, headerQuery])
-            .then((response) => {
-              const tableResults = response[0];
-              const metadata = Object.values(response[1].data)[0];
-              // Validate metadata structure
-              const universeData = metadata.find((row) => row.name === "universe");
-              const descriptionData = metadata.find((row) => row.name === "descriptn");
-
-              this.setState({
-                rows: tableResults.data.rows,
-                universe: universeData ? universeData.details : "",
-                description: descriptionData ? descriptionData.details : "",
-                columnKeys: metadata
-                  .filter((object) => tableResults.data.rows[0] && Object.keys(tableResults.data.rows[0]).includes(object.name))
-                  .filter((header) => header.name !== "seq_id"),
-                metadata,
-                table: dataset.table_name,
-                schema: dataset.schemaname,
-                database: dataset.db_name,
-                title: dataset.menu3,
-                source: dataset.source,
-                queryYearColumn: dataset.yearcolumn,
-                loading: false,
-              });
-            })
-            .catch((error) => {
-              this.setState({ loading: false, error: "Error loading dataset" });
-              console.error("Error:", error);
-            });
-        }
+          })
+          .catch((error) => {
+            this.setState({ loading: false, error: "Error loading dataset" });
+            console.error("Error:", error);
+          });
       } else {
         axios
           .all([tableQuery, headerQuery])
-          .then(async (response) => {
+          .then((response) => {
             const tableResults = response[0];
             const metadata = Object.values(response[1].data)[0];
+            // Validate metadata structure
+            const universeData = metadata.find((row) => row.name === "universe");
+            const descriptionData = metadata.find((row) => row.name === "descriptn");
 
-            try {
-              const columns = Object.keys(tableResults.data.rows[0] || {});
-              const sortedMetadata = metadata.documentation.metadata.eainfo.detailed.attr
-                .map((attribute) => ({
-                  name: attribute.attrlabl,
-                  alias: attribute.attalias,
-                }))
-                .filter((header) => columns.includes(header.name))
-                .filter((header) => header.name !== "shape");
-
-              this.setState({
-                rows: tableResults.data.rows,
-                columnKeys: sortedMetadata,
-                metadata,
-                description: metadata.documentation.metadata.dataIdInfo.idPurp || "",
-                schema: dataset.schemaname,
-                source: dataset.source,
-                database: dataset.db_name,
-                table: dataset.table_name,
-                title: dataset.menu3,
-                loading: false,
-              });
-            } catch (error) {
-              this.setState({
-                loading: false,
-                error: "Error parsing metadata",
-              });
-              console.error("Error parsing metadata:", error);
-            }
+            this.setState({
+              rows: tableResults.data.rows,
+              universe: universeData ? universeData.details : "",
+              description: descriptionData ? descriptionData.details : "",
+              columnKeys: metadata
+                .filter((object) => tableResults.data.rows[0] && Object.keys(tableResults.data.rows[0]).includes(object.name))
+                .filter((header) => header.name !== "seq_id"),
+              metadata,
+              table: dataset.table_name,
+              schema: dataset.schemaname,
+              database: dataset.db_name,
+              title: dataset.menu3,
+              source: dataset.source,
+              queryYearColumn: dataset.yearcolumn,
+              loading: false,
+            });
           })
           .catch((error) => {
-            this.setState({ loading: false, error: "Error fetching datasets" });
+            this.setState({ loading: false, error: "Error loading dataset" });
             console.error("Error:", error);
           });
       }
-    });
+    } else {
+      axios
+        .all([tableQuery, headerQuery])
+        .then(async (response) => {
+          const tableResults = response[0];
+          const metadata = Object.values(response[1].data)[0];
+
+          try {
+            const columns = Object.keys(tableResults.data.rows[0] || {});
+            const sortedMetadata = metadata.documentation.metadata.eainfo.detailed.attr
+              .map((attribute) => ({
+                name: attribute.attrlabl,
+                alias: attribute.attalias,
+              }))
+              .filter((header) => columns.includes(header.name))
+              .filter((header) => header.name !== "shape");
+
+            this.setState({
+              rows: tableResults.data.rows,
+              columnKeys: sortedMetadata,
+              metadata,
+              description: metadata.documentation.metadata.dataIdInfo.idPurp || "",
+              schema: dataset.schemaname,
+              source: dataset.source,
+              database: dataset.db_name,
+              table: dataset.table_name,
+              title: dataset.menu3,
+              loading: false,
+            });
+          } catch (error) {
+            this.setState({
+              loading: false,
+              error: "Error parsing metadata",
+            });
+            console.error("Error parsing metadata:", error);
+          }
+        })
+        .catch((error) => {
+          this.setState({ loading: false, error: "Error fetching datasets" });
+          console.error("Error:", error);
+        });
+    }
+  }
+
+  componentWillUnmount() {
+    // Reset the flag when component unmounts
+    this.hasLoaded = false;
   }
 
   updateSelectedYears(e, year) {


### PR DESCRIPTION
Fix print charts to include all categories and optimize data loading

- Fix print charts button to load all chart data from all categories before printing
- Add data loading logic to skip API calls when data is already cached
- Hide interactive buttons (View Data, Download Data, Download Image, Download All Data) in print output
- Add print-specific CSS to show all tabs and arrange charts side-by-side (50% width each)
- Improve print layout with proper spacing and responsive chart sizing

Resolves issue where print charts only showed demographics data when other category tabs weren't visited.