### PR TITLE
update housing cost burden chart to be grouped chart

### DIFF
--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -292,7 +292,7 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
               </header>
               <div className="tab__row">
                 <ChartDetails chart={charts.housing.cost_burden} muni={muni} onViewData={handleShowModal}>
-                  <StackedBarChart chart={charts.housing.cost_burden} muni={muni} />
+                  <GroupedBarChart chart={charts.housing.cost_burden} muni={muni} />
                 </ChartDetails>
                 <ChartDetails chart={charts.housing.units_permitted} muni={muni} onViewData={handleShowModal}>
                   <StackedBarChart chart={charts.housing.units_permitted} muni={muni} />

--- a/src/components/RPAregionProfilesView.jsx
+++ b/src/components/RPAregionProfilesView.jsx
@@ -406,7 +406,7 @@ const RPAregionProfilesView = () => {
                   onViewData={handleShowModal}
                   isRPAregion={true}
                 >
-                  <StackedBarChart
+                  <GroupedBarChart
                     chart={charts.housing.cost_burden}
                     muni={rpaId}
                     isRPAregion={true}

--- a/src/components/SubregionProfilesView.jsx
+++ b/src/components/SubregionProfilesView.jsx
@@ -496,7 +496,7 @@ const SubregionProfilesView = () => {
                   onViewData={handleShowModal}
                   isSubregion={true}
                 >
-                  <StackedBarChart
+                  <GroupedBarChart
                     chart={charts.housing.cost_burden}
                     muni={subregionId}
                     isSubregion={true}

--- a/src/components/visualizations/GroupedBarChart.jsx
+++ b/src/components/visualizations/GroupedBarChart.jsx
@@ -188,8 +188,7 @@ const GroupedBarChart = (props) => {
             const count = d.count;
             const countMe = d.countMarginOfError;
 
-            const isPercentChart =
-              props.chart?.title === "Internet Subscription Types" || props.chart?.title === "Educational Attainment by Race";
+            const isPercentChart = props.chart?.tooltip?.type === "percentAndCount";
             
             // For percent-based charts, values are already in percent units (with a percent sign added below).
             const formattedValue = typeof value === "number"

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -880,6 +880,7 @@ export default {
     edu_attainment_by_race: {
       type: "grouped-bar",
       title: "Educational Attainment by Race",
+      tooltip: { type: "percentAndCount" },
       xAxis: {
         label: "Level of Education",
         format: format.string.default,
@@ -1539,7 +1540,7 @@ SELECT CONCAT(MIN(cal_year), '-', MAX(cal_year)) AS latest_year FROM years;`;
   },
   housing: {
     cost_burden: {
-      type: "stacked-bar",
+      type: "grouped-bar",
       title: "Housing Cost Burden",
       tooltip: { type: "percentAndCount" },
       xAxis: { label: "Cost Burden Categories" },
@@ -2656,6 +2657,7 @@ SELECT CONCAT(MIN(cal_year), '-', MAX(cal_year)) AS latest_year FROM years;`;
     internet_subscription_types: {
       type: "grouped-bar",
       title: "Internet Subscription Types",
+      tooltip: { type: "percentAndCount" }, // Used by GroupedBarChart to format percent + margin-of-error + counts
       xAxis: {
         label: "Subscription Type",
         format: format.string.default,


### PR DESCRIPTION
- Updated the Housing Cost Burden chart from stacked bar chart to be grouped bar chart to match our db data
- remove the hardcoded logic based on chart titles and replace it with a configurable parameter in the chart configuration. 

