### PR TITLE
clarify tooltip content based on data source and hovering improvement

### DIFF
--- a/src/assets/styles/modules/chart.scss
+++ b/src/assets/styles/modules/chart.scss
@@ -25,6 +25,10 @@
       .donut-segment--print {
         display: block;
       }
+      // Ensure label is visible and final if print runs before the fade-in transition finishes
+      .gauge-text {
+        opacity: 1 !important;
+      }
     }
     
     .svg-wrapper {

--- a/src/components/visualizations/GaugeChart.jsx
+++ b/src/components/visualizations/GaugeChart.jsx
@@ -4,6 +4,7 @@ import * as d3 from "d3";
 import MoonLoader from "react-spinners/MoonLoader";
 
 import colors from "../../constants/colors";
+import { chartSourceIsAcs } from "../../constants/charts";
 
 const primaryColors = Array.from(colors.CHART.PRIMARY.values());
 
@@ -133,6 +134,10 @@ const GaugeChart = (props) => {
       .attr("stroke-dasharray", `0 ${fullCirc}`)
       .attr("stroke-dashoffset", -halfCirc)
       .on("mouseover", (event) => {
+        const isAcs = chartSourceIsAcs(props.chart);
+        const countLabel = isAcs ? "Estimate" : "Count";
+        const countMeLabel = isAcs ? "Margin of Error (Estimate)" : "Margin of Error (Count)";
+
         const formattedPercentage = props.valueFormat ? `${props.valueFormat(value)}%` : `${value.toFixed(1)}%`;
         const formattedME = marginOfError !== null ? (marginOfError % 1 === 0 ? marginOfError.toFixed(0) : marginOfError.toFixed(1)) : null;
         const formattedCount = count !== null ? d3.format(",")(count) : null;
@@ -142,6 +147,24 @@ const GaugeChart = (props) => {
               ? countMarginOfError.toFixed(0)
               : countMarginOfError.toFixed(1)
             : null;
+
+        const valueMeLine =
+          formattedME !== null
+            ? `<div>Margin of Error (Percent): ±${formattedME}%</div>`
+            : isAcs
+              ? `<div>Margin of Error (Percent): Not Available</div>`
+              : "";
+        const countMeLine =
+          formattedCountME !== null
+            ? `<div>${countMeLabel}: ±${formattedCountME}</div>`
+            : isAcs && formattedCount !== null
+              ? `<div>${countMeLabel}: Not Available</div>`
+              : "";
+        const countBlock =
+          formattedCount !== null
+            ? `<div style="margin-top: 4px;"><div>${countLabel}: ${formattedCount}</div>${countMeLine}</div>`
+            : "";
+
         tooltip
           .style("opacity", 1)
           .html(
@@ -149,15 +172,8 @@ const GaugeChart = (props) => {
             <div style="padding: 4px;">
               <div style="font-weight: bold;">${props.title || "Value"}</div>
               <div>Value: ${formattedPercentage}</div>
-              ${formattedME !== null ? `<div>Margin of Error: ±${formattedME}%</div>` : '<div>Margin of Error: Not Available</div>'}
-              ${
-                formattedCount !== null
-                  ? `<div style="margin-top: 4px;">Count: ${formattedCount}</div>
-                     <div>Margin of Error (Count): ${
-                       formattedCountME !== null ? `±${formattedCountME}` : "Not Available"
-                     }</div>`
-                  : ""
-              }
+              ${valueMeLine}
+              ${countBlock}
             </div>
           `,
           )
@@ -184,8 +200,9 @@ const GaugeChart = (props) => {
         };
       });
 
-    // Value text near bottom center — count up and fade in
-    const formattedValue = props.valueFormat ? props.valueFormat(value) : value.toFixed(1);
+    // Center label: final value set immediately so print / PDF never snapshots a counting "0%" mid-animation.
+    // (Arc uses a static print layer; text must match.)
+    const displayLabel = props.valueFormat ? `${props.valueFormat(value)}%` : `${value.toFixed(1)}%`;
     const valueText = chart
       .append("text")
       .attr("x", cx)
@@ -196,21 +213,9 @@ const GaugeChart = (props) => {
       .attr("font-weight", "400")
       .attr("fill", valueColor)
       .attr("opacity", 0)
-      .text("0%");
+      .text(displayLabel);
 
-    valueText
-      .transition()
-      .delay(400)
-      .duration(800)
-      .ease(d3.easeCubicOut)
-      .attr("opacity", 1)
-      .textTween(function () {
-        const interp = d3.interpolateNumber(0, value);
-        const format = props.valueFormat || ((n) => n.toFixed(1));
-        return function (t) {
-          return `${format(interp(t))}%`;
-        };
-      });
+    valueText.transition().delay(200).duration(400).ease(d3.easeCubicOut).attr("opacity", 1);
   };
 
   const renderBlankChart = () => {
@@ -274,6 +279,7 @@ const GaugeChart = (props) => {
 };
 
 GaugeChart.propTypes = {
+  chart: PropTypes.object,
   data: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.number.isRequired,

--- a/src/components/visualizations/GroupedBarChart.jsx
+++ b/src/components/visualizations/GroupedBarChart.jsx
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 import * as d3 from "d3";
 
 import colors from "../../constants/colors";
-import { drawLegend, maxTextToMargin, sortKeys, splitPhrase } from "../../utils/charts";
+import { chartSourceIsAcs } from "../../constants/charts";
+import { drawLegend, maxTextToMargin, MIN_BAR_POINTER_TARGET, sortKeys, splitPhrase } from "../../utils/charts";
 
 const primaryColors = Array.from(colors.CHART.PRIMARY.values());
 const extendedColors = Array.from(colors.CHART.EXTENDED.values());
@@ -170,23 +171,24 @@ const GroupedBarChart = (props) => {
     // Create chart group
     const g = chart.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
 
-    // Add bars
+    // Add bars (visible + transparent hit target so tiny bars stay easy to hover)
     nestedData.forEach((group) => {
       group.values.forEach((d) => {
-        const bar = g
-          .append("rect")
-          .attr("x", xScale(d.x) + zScale(d.z))
-          .attr("y", yScale(d.y))
-          .attr("width", zScale.bandwidth())
-          .attr("height", height - yScale(d.y))
-          .attr("fill", colorRef.current(d.z))
-          .on("mouseover", (event) => {
+        const bx = xScale(d.x) + zScale(d.z);
+        const bw = zScale.bandwidth();
+        const barTop = yScale(d.y);
+        const visualH = height - barTop;
+        const hitH = Math.max(visualH, MIN_BAR_POINTER_TARGET);
+        const hitY = height - hitH;
+
+        const showTooltip = (event) => {
             const value = d.y;
             const me = d.me;
             const totpop = d.totpop;
             const totpop_me = d.totpop_me;
             const count = d.count;
             const countMe = d.countMarginOfError;
+            const isAcs = chartSourceIsAcs(props.chart);
 
             const isPercentChart = props.chart?.tooltip?.type === "percentAndCount";
             
@@ -214,11 +216,41 @@ const GroupedBarChart = (props) => {
                 : null;
 
             const valueDisplay = formattedValue;
-            const meDisplay = formattedME === null ? "Not Available" : (isPercentChart ? `±${formattedME}%` : `±${formattedME}`);
-
             const valueIsPercent = typeof valueDisplay === "string" && valueDisplay.includes("%");
-            const valueLabel = valueIsPercent ? "Percent (%)" : "Count";
-            const meLabel = valueIsPercent ? "Margin of Error (Percent)" : "Margin of Error (Count)";
+            const countOrEstimate = isAcs ? "Estimate" : "Count";
+            const valueLabel = valueIsPercent ? "Percent (%)" : countOrEstimate;
+            const meLabel = valueIsPercent
+              ? "Margin of Error (Percent)"
+              : isAcs
+                ? "Margin of Error (Estimate)"
+                : "Margin of Error (Count)";
+            const primaryMeDisplay =
+              formattedME === null
+                ? null
+                : isPercentChart
+                  ? `±${formattedME}%`
+                  : `±${formattedME}`;
+            const primaryMeLine =
+              primaryMeDisplay !== null
+                ? `<div>${meLabel}: ${primaryMeDisplay}</div>`
+                : isAcs
+                  ? `<div>${meLabel}: Not Available</div>`
+                  : "";
+            const countBlockLabel = countOrEstimate;
+            const countMeBlockLabel = isAcs ? "Margin of Error (Estimate)" : "Margin of Error (Count)";
+            const countMeLine =
+              formattedCountME !== null
+                ? `<div>${countMeBlockLabel}: ±${formattedCountME}</div>`
+                : isAcs
+                  ? `<div>${countMeBlockLabel}: Not Available</div>`
+                  : "";
+            const totalPopulationLabel = isAcs ? "Total Population (estimate)" : "Total Population";
+            const totalMeLine =
+              formattedTotpopME != null
+                ? `<div>Total Margin of Error: ±${formattedTotpopME}</div>`
+                : isAcs
+                  ? `<div>Total Margin of Error: Not Available</div>`
+                  : "";
 
             tooltip
               .style("opacity", 1)
@@ -227,15 +259,13 @@ const GroupedBarChart = (props) => {
                 <div style="padding: 4px;">
                   <div style="font-weight: bold;">${d.z}</div>
                   <div>${valueLabel}: ${valueDisplay}</div>
-                  <div>${meLabel}: ${meDisplay}</div>
+                  ${primaryMeLine}
                   ${
                     formattedCount !== null
                       ? `
                     <div style="margin-top: 4px;">
-                      <div>Count: ${formattedCount}</div>
-                      <div>Margin of Error (Count): ${
-                        formattedCountME !== null ? `±${formattedCountME}` : "Not Available"
-                      }</div>
+                      <div>${countBlockLabel}: ${formattedCount}</div>
+                      ${countMeLine}
                     </div>
                   `
                       : ""
@@ -244,8 +274,8 @@ const GroupedBarChart = (props) => {
                     formattedTotpop
                       ? `
                     <div style="margin-top: 8px; border-top: 1px solid #ccc; padding-top: 8px;">
-                      <div>Total Population: ${formattedTotpop}</div>
-                      <div>Total Margin of Error: ${formattedTotpopME === null ? "Not Available" : "±" + formattedTotpopME}</div>
+                      <div>${totalPopulationLabel}: ${formattedTotpop}</div>
+                      ${totalMeLine}
                     </div>
                   `
                       : ""
@@ -255,7 +285,26 @@ const GroupedBarChart = (props) => {
               )
               .style("left", `${event.pageX + 10}px`)
               .style("top", `${event.pageY - 10}px`);
-          })
+        };
+
+        g.append("rect")
+          .attr("x", bx)
+          .attr("y", barTop)
+          .attr("width", bw)
+          .attr("height", visualH)
+          .attr("fill", colorRef.current(d.z))
+          .attr("pointer-events", "none");
+
+        g.append("rect")
+          .attr("class", "bar-hit-area")
+          .attr("x", bx)
+          .attr("y", hitY)
+          .attr("width", bw)
+          .attr("height", hitH)
+          .attr("fill", "transparent")
+          .attr("pointer-events", "all")
+          .style("cursor", "default")
+          .on("mouseover", showTooltip)
           .on("mousemove", (event) => {
             tooltip.style("left", `${event.pageX + 10}px`).style("top", `${event.pageY - 10}px`);
           })

--- a/src/components/visualizations/PieChart.jsx
+++ b/src/components/visualizations/PieChart.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import * as d3 from "d3";
 
 import colors from "../../constants/colors";
+import { chartSourceIsAcs } from "../../constants/charts";
 import { maxTextToMargin, drawLegend } from "../../utils/charts";
 
 const primaryColors = Array.from(colors.CHART.PRIMARY.values());
@@ -129,12 +130,16 @@ class PieChart extends React.Component {
       .attr("stroke", "white")
       .attr("stroke-width", "1")
       .on("mouseover", (event, d) => {
+        const isAcs = chartSourceIsAcs(this.props.chart);
+        const countLabel = isAcs ? "Estimate" : "Count";
+        const meLabel = isAcs ? "Margin of Error (Estimate)" : "Margin of Error (Count)";
+
         const percentage = ((d.data.value * 100) / sum).toFixed(1);
         const count = d.data.count ?? d.data.value;
         const countME = d.data.countMarginOfError ?? d.data.me;
         const formattedCount = typeof count === "number" ? d3.format(",")(count) : null;
         const formattedME = typeof countME === "number" ? d3.format(",")(countME) : null;
-        
+
         let tooltipContent = `
           <div style="padding: 4px;">
             <div style="font-weight: bold;">${d.data.label}</div>
@@ -142,15 +147,15 @@ class PieChart extends React.Component {
         `;
 
         if (formattedCount !== null) {
-          tooltipContent += `<div>Count: ${formattedCount}</div>`;
+          tooltipContent += `<div>${countLabel}: ${formattedCount}</div>`;
         }
-        
+
         if (formattedME !== null) {
-          tooltipContent += `<div>Margin of Error (Count): ±${formattedME}</div>`;
-        } else {
-          tooltipContent += `<div>Margin of Error (Count): Not Available</div>`;
+          tooltipContent += `<div>${meLabel}: ±${formattedME}</div>`;
+        } else if (isAcs && formattedCount !== null) {
+          tooltipContent += `<div>${meLabel}: Not Available</div>`;
         }
-        
+
         tooltipContent += `</div>`;
         
         this.tooltip
@@ -208,7 +213,7 @@ class PieChart extends React.Component {
 }
 
 PieChart.propTypes = {
-  colors: PropTypes.arrayOf(PropTypes.string),
+  chart: PropTypes.object,
   title: PropTypes.string,
   data: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/visualizations/StackedBarChart.jsx
+++ b/src/components/visualizations/StackedBarChart.jsx
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 import * as d3 from "d3";
 
 import colors from "../../constants/colors";
-import { drawLegend, maxTextToMargin, sortKeys, splitPhrase } from "../../utils/charts";
+import { chartSourceIsAcs } from "../../constants/charts";
+import { drawLegend, maxTextToMargin, MIN_BAR_POINTER_TARGET, sortKeys, splitPhrase } from "../../utils/charts";
 
 const primaryColors = Array.from(colors.CHART.PRIMARY.values());
 const extendedColors = Array.from(colors.CHART.EXTENDED.values());
@@ -45,12 +46,22 @@ const StackedBarChart = (props) => {
     pctRaw,
     pctMeRaw,
     extraHtml = "",
+    isAcs,
   }) => {
     const pct = pctRaw == null || pctRaw === "" ? NaN : Number(pctRaw);
     const pctMe = pctMeRaw == null || pctMeRaw === "" ? NaN : Number(pctMeRaw);
 
-    const pctDisplay = Number.isFinite(pct) ? `${pct.toFixed(1)}%` : "Not Available";
-    const pctMeDisplay = Number.isFinite(pctMe) ? `±${pctMe.toFixed(1)}%` : "Not Available";
+    const pctLine = Number.isFinite(pct)
+      ? `<div>${pctLabel}: ${pct.toFixed(1)}%</div>`
+      : isAcs
+        ? `<div>${pctLabel}: Not Available</div>`
+        : "";
+    const pctMeLine = Number.isFinite(pctMe)
+      ? `<div>${pctMeLabel}: ±${pctMe.toFixed(1)}%</div>`
+      : isAcs
+        ? `<div>${pctMeLabel}: Not Available</div>`
+        : "";
+    const primaryMeLine = meDisplay != null ? `<div>${meLabel}: ${meDisplay}</div>` : "";
 
     tooltip
       .style("opacity", 1)
@@ -59,9 +70,9 @@ const StackedBarChart = (props) => {
         <div style="padding: 4px;">
           <div style="font-weight: bold;">${seriesLabel}</div>
           <div>${valueLabel}: ${valueDisplay}</div>
-          <div>${meLabel}: ${meDisplay}</div>
-          <div>${pctLabel}: ${pctDisplay}</div>
-          <div>${pctMeLabel}: ${pctMeDisplay}</div>
+          ${primaryMeLine}
+          ${pctLine}
+          ${pctMeLine}
           ${extraHtml}
         </div>
       `,
@@ -241,37 +252,12 @@ const StackedBarChart = (props) => {
     // Create chart group
     const g = chart.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
 
-    // Add bars
-    const layers = g
-      .selectAll("g.layer")
-      .data(stack(data))
-      .join("g")
-      .attr("class", "layer")
-      .attr("fill", (d) => colorRef.current(d.key));
-
-    layers
-      .selectAll("rect")
-      .data((d) => d.map((item) => ({ ...item, series: d.key })))
-      .join("rect")
-      .attr("x", (d) => {
-        if (props.horizontal) {
-          return xScale(d[0]);
-        }
-        return xScale(d.data.x) + realignment;
-      })
-      .attr("y", (d) => (props.horizontal ? yScale(d.data.x) : isNaN(yScale(d[1])) ? yScale(0) : yScale(d[1])))
-      .attr("height", (d) => (props.horizontal ? yScale.bandwidth() : isNaN(yScale(d[0]) - yScale(d[1])) ? 0 : Math.max(0, yScale(d[0]) - yScale(d[1]))))
-      .attr("width", (d) => {
-        if (props.horizontal) {
-          return Math.max(0, xScale(d[1]) - xScale(d[0]));
-        }
-        return columnWidth;
-      })
-      .on("mouseover", (event, d) => {
+    const stackedBarPointer = (event, d) => {
         const value = d.data[d.series];
         const me = d.data[`${d.series}_me`];
         const totpop = d.data.totpop;
         const totpop_me = d.data.totpop_me;
+        const isAcs = chartSourceIsAcs(props.chart);
 
         const isPercentChart = props.chart?.title === "Internet Usage by Income Level";
         
@@ -292,7 +278,14 @@ const StackedBarChart = (props) => {
         const formattedTotpopME = typeof totpop_me === "number" ? d3.format(",")(totpop_me) : null;
         
         const valueDisplay = formattedValue;
-        const meDisplay = formattedME === null ? "Not Available" : (isPercentChart ? `±${formattedME}%` : `±${formattedME}`);
+        const meDisplay =
+          formattedME === null
+            ? isAcs
+              ? "Not Available"
+              : null
+            : isPercentChart
+              ? `±${formattedME}%`
+              : `±${formattedME}`;
 
         const tooltipType = props.chart?.tooltip?.type;
         const showTotalsInTooltip = !!props.chart?.tooltip?.showTotals;
@@ -307,12 +300,19 @@ const StackedBarChart = (props) => {
                 : "default");
 
         if (resolvedTooltipType === "countAndPercent") {
+          const totalPopulationLabel = isAcs ? "Total Population (estimate)" : "Total Population";
+          const totalMeHtml =
+            formattedTotpopME != null
+              ? `<div>Margin of Error: ±${formattedTotpopME}</div>`
+              : isAcs
+                ? `<div>Margin of Error: Not Available</div>`
+                : "";
           const extraHtml =
             (showTotalsInTooltip || props.chart.title === "Employment of Residents") && formattedTotpop
               ? `
                 <div style="margin-top: 8px; border-top: 1px solid #ccc; padding-top: 8px;">
-                  <div>Total Population: ${formattedTotpop}</div>
-                  <div>Total Margin of Error: ${formattedTotpopME === null ? "Not Available" : "±" + formattedTotpopME}</div>
+                  <div>${totalPopulationLabel}: ${formattedTotpop}</div>
+                  ${totalMeHtml}
                 </div>
               `
               : "";
@@ -322,22 +322,27 @@ const StackedBarChart = (props) => {
             event,
             tooltip,
             seriesLabel: d.series,
-            valueLabel: "Count",
+            valueLabel: isAcs ? "Estimate" : "Count",
             valueDisplay,
-            meLabel: "Margin of Error (Count)",
+            meLabel: isAcs ? "Margin of Error (Estimate)" : "Margin of Error (Count)",
             meDisplay,
             pctLabel: "Percent (%)",
             pctMeLabel: "Margin of Error (Percent)",
             pctRaw: d.data[`${d.series}_pct`] ?? d.data.pct,
             pctMeRaw: d.data[`${d.series}_pct_me`] ?? d.data.pct_me,
             extraHtml,
+            isAcs,
           });
         } else if (resolvedTooltipType === "percentAndCount") {
           // Percent + percent MOE primary value and count + count MOE secondary metrics.
           const pct = typeof value === "number" ? value : parseFloat(value);
           const pctMe = typeof me === "number" ? me : NaN;
-          const pctDisplay = !isNaN(pct) ? `${pct.toFixed(1)}%` : "Not Available";
-          const pctMeDisplay = !isNaN(pctMe) ? `±${pctMe.toFixed(1)}%` : "Not Available";
+          const pctDisplay = !isNaN(pct) ? `${pct.toFixed(1)}%` : isAcs ? "Not Available" : null;
+          const pctMeLine = !isNaN(pctMe)
+            ? `<div>Margin of Error (Percent): ±${pctMe.toFixed(1)}%</div>`
+            : isAcs
+              ? `<div>Margin of Error (Percent): Not Available</div>`
+              : "";
 
           const seriesCount = d.data[`${d.series}_count`];
           const seriesCountMe = d.data[`${d.series}_count_me`];
@@ -348,6 +353,14 @@ const StackedBarChart = (props) => {
                 ? d3.format(",")(seriesCountMe)
                 : d3.format(",.1f")(seriesCountMe)
               : null;
+          const countLabel = isAcs ? "Estimate" : "Count";
+          const countMeLabel = isAcs ? "Margin of Error (Estimate)" : "Margin of Error (Count)";
+          const countMeLine =
+            formattedCountME !== null
+              ? `<div>${countMeLabel}: ±${formattedCountME}</div>`
+              : isAcs
+                ? `<div>${countMeLabel}: Not Available</div>`
+                : "";
 
           tooltip
             .style("opacity", 1)
@@ -355,14 +368,12 @@ const StackedBarChart = (props) => {
               `
             <div style="padding: 4px;">
               <div style="font-weight: bold;">${d.series}</div>
-              <div>Percent (%): ${pctDisplay}</div>
-              <div>Margin of Error (Percent): ${pctMeDisplay}</div>
+              ${pctDisplay != null ? `<div>Percent (%): ${pctDisplay}</div>` : ""}
+              ${pctMeLine}
               ${
                 formattedCount !== null
-                  ? `<div style="margin-top: 4px;">Count: ${formattedCount}</div>
-                     <div>Margin of Error (Count): ${
-                       formattedCountME !== null ? `±${formattedCountME}` : "Not Available"
-                     }</div>`
+                  ? `<div style="margin-top: 4px;"><div>${countLabel}: ${formattedCount}</div>
+                     ${countMeLine}</div>`
                   : ""
               }
             </div>
@@ -381,8 +392,28 @@ const StackedBarChart = (props) => {
                 : d3.format(",.1f")(countMe)
               : null;
           const valueIsPercent = typeof valueDisplay === "string" && valueDisplay.includes("%");
-          const valueLabel = valueIsPercent ? "Percent (%)" : "Count";
-          const meLabel = valueIsPercent ? "Margin of Error (Percent)" : "Margin of Error (Count)";
+          const countOrEstimate = isAcs ? "Estimate" : "Count";
+          const valueLabel = valueIsPercent ? "Percent (%)" : countOrEstimate;
+          const meLabel = valueIsPercent
+            ? "Margin of Error (Percent)"
+            : isAcs
+              ? "Margin of Error (Estimate)"
+              : "Margin of Error (Count)";
+          const primaryMeLine = meDisplay != null ? `<div>${meLabel}: ${meDisplay}</div>` : "";
+          const countMeLabel = isAcs ? "Margin of Error (Estimate)" : "Margin of Error (Count)";
+          const countMeLine =
+            formattedCountME !== null
+              ? `<div>${countMeLabel}: ±${formattedCountME}</div>`
+              : isAcs
+                ? `<div>${countMeLabel}: Not Available</div>`
+                : "";
+          const totalPopulationLabel = isAcs ? "Total Population (estimate)" : "Total Population";
+          const totalMeLine =
+            formattedTotpopME != null
+              ? `<div>Total Margin of Error: ±${formattedTotpopME}</div>`
+              : isAcs
+                ? `<div>Total Margin of Error: Not Available</div>`
+                : "";
 
           tooltip
             .style("opacity", 1)
@@ -391,21 +422,19 @@ const StackedBarChart = (props) => {
             <div style="padding: 4px;">
               <div style="font-weight: bold;">${d.series}</div>
               <div>${valueLabel}: ${valueDisplay}</div>
-              <div>${meLabel}: ${meDisplay}</div>
+              ${primaryMeLine}
               ${
                 formattedCount !== null
-                  ? `<div style="margin-top: 4px;">Count: ${formattedCount}</div>
-                     <div>Margin of Error (Count): ${
-                       formattedCountME !== null ? `±${formattedCountME}` : "Not Available"
-                     }</div>`
+                  ? `<div style="margin-top: 4px;"><div>${countOrEstimate}: ${formattedCount}</div>
+                     ${countMeLine}</div>`
                   : ""
               }
               ${
                 formattedTotpop
                   ? `
                 <div style="margin-top: 8px; border-top: 1px solid #ccc; padding-top: 8px;">
-                  <div>Total Population: ${formattedTotpop}</div>
-                  <div>Total Margin of Error: ${formattedTotpopME === null ? "Not Available" : "±" + formattedTotpopME}</div>
+                  <div>${totalPopulationLabel}: ${formattedTotpop}</div>
+                  ${totalMeLine}
                 </div>
               `
                   : ""
@@ -416,15 +445,104 @@ const StackedBarChart = (props) => {
             .style("left", `${event.pageX + 10}px`)
             .style("top", `${event.pageY - 10}px`);
         }
+    };
 
-       
-      })
-      .on("mousemove", (event) => {
-        tooltip.style("left", `${event.pageX + 10}px`).style("top", `${event.pageY - 10}px`);
-      })
-      .on("mouseout", () => {
-        tooltip.style("opacity", 0);
-      });
+    const stackedBarMove = (event) => {
+      tooltip.style("left", `${event.pageX + 10}px`).style("top", `${event.pageY - 10}px`);
+    };
+
+    const stackedBarLeave = () => {
+      tooltip.style("opacity", 0);
+    };
+
+    // Add bars (visible + transparent hit target so tiny segments stay easy to hover)
+    const layers = g
+      .selectAll("g.layer")
+      .data(stack(data))
+      .join("g")
+      .attr("class", "layer")
+      .attr("fill", (d) => colorRef.current(d.key));
+
+    layers.each(function (layerRows) {
+      const layerG = d3.select(this);
+      const cells = layerRows.map((item) => ({ ...item, series: layerRows.key }));
+
+      layerG
+        .selectAll("rect.bar-visible")
+        .data(cells)
+        .join("rect")
+        .attr("class", "bar-visible")
+        .attr("pointer-events", "none")
+        .attr("x", (d) => {
+          if (props.horizontal) {
+            return xScale(d[0]);
+          }
+          return xScale(d.data.x) + realignment;
+        })
+        .attr("y", (d) => (props.horizontal ? yScale(d.data.x) : isNaN(yScale(d[1])) ? yScale(0) : yScale(d[1])))
+        .attr("height", (d) =>
+          props.horizontal ? yScale.bandwidth() : isNaN(yScale(d[0]) - yScale(d[1])) ? 0 : Math.max(0, yScale(d[0]) - yScale(d[1])),
+        )
+        .attr("width", (d) => {
+          if (props.horizontal) {
+            return Math.max(0, xScale(d[1]) - xScale(d[0]));
+          }
+          return columnWidth;
+        });
+
+      layerG
+        .selectAll("rect.bar-hit")
+        .data(cells)
+        .join("rect")
+        .attr("class", "bar-hit")
+        .attr("fill", "transparent")
+        .attr("pointer-events", "all")
+        .style("cursor", "default")
+        .attr("x", (d) => {
+          if (props.horizontal) {
+            const xL = xScale(d[0]);
+            const xR = xScale(d[1]);
+            const visualW = Math.max(0, xR - xL);
+            const hitW = Math.max(visualW, MIN_BAR_POINTER_TARGET);
+            return xR - hitW;
+          }
+          return xScale(d.data.x) + realignment;
+        })
+        .attr("y", (d) => {
+          if (props.horizontal) {
+            const band = yScale.bandwidth();
+            const hitBand = Math.max(band, MIN_BAR_POINTER_TARGET);
+            const y0 = yScale(d.data.x);
+            return y0 + (band - hitBand) / 2;
+          }
+          const yTop = isNaN(yScale(d[1])) ? yScale(0) : yScale(d[1]);
+          const yBottom = isNaN(yScale(d[0])) ? yScale(0) : yScale(d[0]);
+          const visualH = Math.max(0, yBottom - yTop);
+          const hitH = Math.max(visualH, MIN_BAR_POINTER_TARGET);
+          return yBottom - hitH;
+        })
+        .attr("height", (d) => {
+          if (props.horizontal) {
+            return Math.max(yScale.bandwidth(), MIN_BAR_POINTER_TARGET);
+          }
+          const yTop = isNaN(yScale(d[1])) ? yScale(0) : yScale(d[1]);
+          const yBottom = isNaN(yScale(d[0])) ? yScale(0) : yScale(d[0]);
+          const visualH = Math.max(0, yBottom - yTop);
+          return Math.max(visualH, MIN_BAR_POINTER_TARGET);
+        })
+        .attr("width", (d) => {
+          if (props.horizontal) {
+            const xL = xScale(d[0]);
+            const xR = xScale(d[1]);
+            const visualW = Math.max(0, xR - xL);
+            return Math.max(visualW, MIN_BAR_POINTER_TARGET);
+          }
+          return columnWidth;
+        })
+        .on("mouseover", stackedBarPointer)
+        .on("mousemove", stackedBarMove)
+        .on("mouseout", stackedBarLeave);
+    });
 
     // Add axes with proper formatting
     const xAxis = props.horizontal

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -305,6 +305,16 @@ const demoRaceByAgeGenderColumns = [
   "pop85o",
 ];
 
+/**
+ * True when chart metadata indicates American Community Survey (ACS) data.
+ * Used for tooltips: "Estimate" / survey MOE wording instead of "Count" for tallies.
+ */
+export const chartSourceIsAcs = (chart) => {
+  const s = chart?.source;
+  if (typeof s !== "string" || !s.trim()) return false;
+  return /american community survey/i.test(s) || /\bACS\b/i.test(s);
+};
+
 export default {
   demographics: {
     race_ethnicity: {

--- a/src/utils/charts.js
+++ b/src/utils/charts.js
@@ -1,3 +1,6 @@
+/** Minimum bar thickness in SVG user units for pointer targets (invisible overlay). */
+export const MIN_BAR_POINTER_TARGET = 14;
+
 export function maxToMargin(maxValue) {
   if (!maxValue) { return 0; }
   const zeros = Math.floor(Math.log10(maxValue)) + 1;


### PR DESCRIPTION
- for acs data in community profile, the tooltip should use estimate instead of count
- it is hard to hover small bar on charts to view the tooltip so I add MIN_BAR_POINTER_TARGET to improve the user experience.
<img width="721" height="653" alt="Screenshot 2026-03-30 at 1 42 09 PM" src="https://github.com/user-attachments/assets/ee2a0ab4-852a-4e17-8c63-a19d3d569b50" />
- when I click print all charts, the gauge chart number is not fully loaded because of the number animation. I make the number to stay visible by setting `{ opacity: 1 !important; }`
