### PR TITLE
allow full columns deselection

### DIFF
--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -481,10 +481,8 @@ const ColumnSelectorDropdown = ({ columnKeys, updateSelectedColumns, selectedCol
               onClick={(e) => {
                 e.stopPropagation();
                 if (selectedCount === totalCount) {
-                  // Deselect all except first (keep at least one selected)
-                  const firstColumn = sortedColumnKeys[0].name;
                   sortedColumnKeys.forEach((col) => {
-                    if (col.name !== firstColumn && selectedColumns.includes(col.name)) {
+                    if (selectedColumns.includes(col.name)) {
                       updateSelectedColumns(col.name);
                     }
                   });

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -272,10 +272,6 @@ class DataViewerClass extends React.Component {
   updateSelectedColumns(columnName) {
     this.setState((prevState) => {
       if (prevState.selectedColumns.includes(columnName)) {
-        // Don't allow deselecting all columns - at least one must be selected
-        if (prevState.selectedColumns.length === 1) {
-          return prevState;
-        }
         const index = prevState.selectedColumns.indexOf(columnName);
         const front = prevState.selectedColumns.slice(0, index);
         const back = prevState.selectedColumns.slice(index + 1);


### PR DESCRIPTION
Allow full column deselection by removing the “keep at least one column” rule and making “Deselect All” clear every column instead of leaving the first one selected.
<img width="1478" height="840" alt="Screenshot 2026-04-09 at 4 19 32 PM" src="https://github.com/user-attachments/assets/8aa2a496-bb40-4912-8093-21c28fee8c6d" />
