### PR TITLE
Moves duplicated dataset management code to shared util file

### DIFF
--- a/src/components/partials/DatasetSearchBar.jsx
+++ b/src/components/partials/DatasetSearchBar.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { filterDatasets, highlightDatasets, sortDatasets } from '../../utils/manageDatasets';
 
 const SearchContainer = styled.div`
   position: relative;
@@ -146,127 +147,19 @@ const DatasetSearchBar = ({
 
   // Filter datasets based on search query
   useEffect(() => {
-    let filtered = datasets || [];
-    let highlights = {};
+    const filtered = filterDatasets({ datasets, searchQuery }); // also removes duplicates by table_name
+    const highlights = highlightDatasets({ searchQuery, datasets: filtered });
+    const sorted = sortDatasets({ searchQuery, datasets: filtered }); // use the default 'Relevance' sort order
 
-    if (searchQuery.trim()) {
-      // break query into individual tokens, filter empty tokens, escape special characters
-      const query = searchQuery.trim();
-      let searchTokens = query.split(" ").filter(st => !!st).map(st => st.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-      searchTokens = [...new Set(searchTokens)];
-
-      filtered = filtered.filter((dataset) => {
-        const tableName = dataset.table_name || '';
-        const datasetName = dataset.menu3 || '';
-
-        const tableNameMatch = searchTokens.some(searchTerm => {
-          const searchRegex = new RegExp(searchTerm, 'i');
-          return searchRegex.test(tableName);
-        });
-
-        const datasetNameMatch = searchTokens.some(searchTerm => {
-          const searchRegex = new RegExp(searchTerm, 'i');
-          return searchRegex.test(datasetName);
-        });
-
-        // manage the highlights
-        if (tableNameMatch || datasetNameMatch) {
-          const datasetId = dataset.seq_id || dataset.id;
-          highlights[datasetId] = [];
-          
-          if (tableNameMatch) {
-            searchTokens.forEach(searchTerm => {
-              const highlightRegex = new RegExp(searchTerm, 'gi');
-              tableName.replace(highlightRegex, (matched, offset) => {
-                const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'table_name' && hl.indices.find(i => i[0] == offset));
-                if (!alreadyMatched) {
-                  highlights[datasetId].push({
-                    key: 'table_name',
-                    indices: [[offset, offset + matched.length - 1]]
-                  });
-                }
-              });
-            });
-          }
-          
-          if (datasetNameMatch) {
-            searchTokens.forEach(searchTerm => {
-              const highlightRegex = new RegExp(searchTerm, 'gi');
-              datasetName.replace(highlightRegex, (matched, offset) => {
-                const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'menu3' && hl.indices.find(i => i[0] == offset));
-                if (!alreadyMatched) {
-                  highlights[datasetId].push({
-                    key: 'menu3',
-                    indices: [[offset, offset + matched.length - 1]]
-                  });
-                }
-              });
-            });
-          }
-        }
-        
-        // return for the filter function
-        return tableNameMatch || datasetNameMatch;
-      });
-
-       // sort the results prioritizing dataset name match over table name match, then sort alphabetically
-      // Count number to tablename and datasetname matches
-      // prioritize higher number of matches and earlier avg index of terms
-      filtered.sort((a, b) => {
-        const datasetNameA = a.menu3 || '';
-        const tableNameA = a.table_name || '';
-        let nameMatchesA = 0;
-        let totalNameIdxA = 0;
-        let tableMatchesA = 0;
-
-        const datasetNameB = b.menu3 || '';
-        const tableNameB = b.table_name || '';
-        let nameMatchesB = 0;
-        let totalNameIdxB = 0;
-        let tableMatchesB = 0;
-        searchTokens.forEach(searchTerm => {
-          const searchRegex = new RegExp(searchTerm, 'i');
-          const nameMatchA = searchRegex.exec(datasetNameA);
-          if (nameMatchA) {
-            nameMatchesA++;
-            totalNameIdxA += nameMatchA.index;
-          }
-          const tableMatchA = searchRegex.exec(tableNameA);
-          if (tableMatchA) {
-            tableMatchesA++;
-          }
-          const nameMatchB = searchRegex.exec(datasetNameB);
-          if (nameMatchB) {
-            nameMatchesB++;
-            totalNameIdxB += nameMatchB.index;
-          }
-          const tableMatchB = searchRegex.exec(tableNameB);
-          if (tableMatchB) {
-            tableMatchesB++;
-          }
-        });
-        const avgNameIdxA = nameMatchesA ? (totalNameIdxA / nameMatchesA) : datasetNameA.length;
-        const avgNameIdxB = nameMatchesB ? (totalNameIdxB / nameMatchesB) : datasetNameB.length;
-
-        if (nameMatchesA != nameMatchesB) {
-          return nameMatchesB - nameMatchesA;
-        } else if (tableMatchesA != tableMatchesB) {
-          return tableMatchesB - tableMatchesA;
-        } else {
-          return avgNameIdxA - avgNameIdxB; // earlier avg index is better
-        }
-      });
-    }
-
-    setHighlightMatches(highlights);
-    const limitedResults = maxResults ? filtered.slice(0, maxResults) : filtered;
+    const limitedResults = maxResults ? sorted.slice(0, maxResults) : sorted;
     setFilteredDatasets(limitedResults);
+    setHighlightMatches(highlights);
     
     // Notify parent component of search results
     if (onSearchChange) {
       onSearchChange({
         query: searchQuery,
-        results: filtered,
+        results: sorted,
         highlights
       });
     }

--- a/src/pages/BrowserPage.jsx
+++ b/src/pages/BrowserPage.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState, useMemo, useRef } from "react";
+import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from "react-router-dom";
+import styled from 'styled-components';
 import { fetchDatasets } from '../reducers/datasetSlice';
 import MetadataModal from "../components/partials/MetadataModal";
 import { formatUpdated, parseUpdatedForSort } from '../utils/formatUpdated';
-import styled from 'styled-components';
+import { filterDatasets, highlightDatasets, sortDatasets } from "../utils/manageDatasets";
 
 const PageContainer = styled.section`
   &.route.categories {
@@ -531,100 +532,19 @@ const BrowserPage = () => {
     return Object.keys(categoryOptionTree).sort();
   }, [categoryOptionTree]);
 
+  // filter datasets and set highlights whenever the filter criteria change
   useEffect(() => {
-    let filtered = datasets || [];
-
-    // reset the scroll height whenever the user changes the search or filter
-    if (datasetGridRef.current) {
-      datasetGridRef.current.scrollTop = 0;
-    }
-
-    if (selectedSources.length > 0) {
-      filtered = filtered.filter(d => {
-        // check if any source in the dataset is a selected source
-        // datasets with multiple sources are separated with '; '
-        return d.source && d.source.split('; ').some(source => selectedSources.includes(source));
-      });
-    }
-
-    if (selectedMenu1s.length > 0 || selectedMenu2s.length > 0) {
-      filtered = filtered.filter(d => selectedMenu1s.includes(d.menu1) || selectedMenu2s.includes(d.menu2));
-    }
-
-    const highlights = {};
-    if (searchQuery.trim()) {
-      // break query into individual tokens, filter empty tokens, escape special characters
-      const query = searchQuery.trim();
-      const searchTokens = query.split(" ").filter(st => !!st).map(st => st.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-
-      filtered = filtered.filter((dataset) => {
-        const tableName = dataset.table_name || '';
-        const datasetName = dataset.menu3 || '';
-
-        const tableNameMatch = searchTokens.some(searchTerm => {
-          const searchRegex = new RegExp(searchTerm, 'i');
-          return searchRegex.test(tableName);
-        });
-
-        const datasetNameMatch = searchTokens.some(searchTerm => {
-          const searchRegex = new RegExp(searchTerm, 'i');
-          return searchRegex.test(datasetName);
-        });
-
-        // manage the highlights
-        if (tableNameMatch || datasetNameMatch) {
-          const datasetId = dataset.seq_id || dataset.id;
-          highlights[datasetId] = [];
-          
-           if (tableNameMatch) {
-            searchTokens.forEach(searchTerm => {
-              const highlightRegex = new RegExp(searchTerm, 'gi');
-              tableName.replace(highlightRegex, (matched, offset) => {
-                const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'table_name' && hl.indices.find(i => i[0] == offset));
-                if (!alreadyMatched) {
-                  highlights[datasetId].push({
-                    key: 'table_name',
-                    indices: [[offset, offset + matched.length - 1]]
-                  });
-                }
-              });
-            });
-          }
-          
-          if (datasetNameMatch) {
-            searchTokens.forEach(searchTerm => {
-              const highlightRegex = new RegExp(searchTerm, 'gi');
-              datasetName.replace(highlightRegex, (matched, offset) => {
-                const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'menu3' && hl.indices.find(i => i[0] == offset));
-                if (!alreadyMatched) {
-                  highlights[datasetId].push({
-                    key: 'menu3',
-                    indices: [[offset, offset + matched.length - 1]]
-                  });
-                }
-              });
-            });
-          }
-        }
-
-        // return for the filter function
-        return tableNameMatch || datasetNameMatch;
-      });
-    }
-
-    // remove the duplicate datasets using table_name to identify duplicates
-    // note: don't use the noDupesDatasets here b/c we do care about having multiple category values
-    //       we want the user to be able to find the same dataset under multiple different categories which is
-    //       why we keep the dupes in the first place
-    const dupesRemoved = [];
-    const seenDatasets = new Set();
-    filtered.forEach(dataset => {
-      if (!seenDatasets.has(dataset.table_name)) {
-        dupesRemoved.push(dataset);
-        seenDatasets.add(dataset.table_name);
-      }
+    // filter based on category, subcategory, sources, and search terms. Also remove duplicates by table_name
+    const filtered = filterDatasets({
+      datasets,
+      searchQuery,
+      sources: selectedSources,
+      categories: selectedMenu1s,
+      subcategories: selectedMenu2s,
     });
-    filtered = dupesRemoved;
+
+    // set the matched search terms to be highlighted
+    const highlights = highlightDatasets({ searchQuery, datasets: filtered });
 
     setHighlightMatches(highlights);
     setDisplayDatasets(filtered);
@@ -685,83 +605,7 @@ const BrowserPage = () => {
 
   // Sort datasets
   const sortedDatasets = useMemo(() => {
-    const sorted = [...displayDatasets];
-
-    let sortType = sortBy;
-    // default from relevance to A -> Z if no search
-    const trimmedSearch = searchQuery.trim();
-    if (!trimmedSearch && sortType === "Relevance") {
-      sortType = "A to Z";
-    }
-    
-    switch (sortType) {
-      case 'Relevance':
-        const searchTokens = trimmedSearch.split(" ").filter(st => !!st).map(st => st.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-        // Count number to tablename and datasetname matches
-        // prioritize higher number of matches and earlier avg index of terms
-        return sorted.sort((a, b) => {
-          const datasetNameA = a.menu3 || '';
-          const tableNameA = a.table_name || '';
-          let nameMatchesA = 0;
-          let totalNameIdxA = 0;
-          let tableMatchesA = 0;
-
-          const datasetNameB = b.menu3 || '';
-          const tableNameB = b.table_name || '';
-          let nameMatchesB = 0;
-          let totalNameIdxB = 0;
-          let tableMatchesB = 0;
-          searchTokens.forEach(searchTerm => {
-            const searchRegex = new RegExp(searchTerm, 'i');
-            const nameMatchA = searchRegex.exec(datasetNameA);
-            if (nameMatchA) {
-              nameMatchesA++;
-              totalNameIdxA += nameMatchA.index;
-            }
-            const tableMatchA = searchRegex.exec(tableNameA);
-            if (tableMatchA) {
-              tableMatchesA++;
-            }
-            const nameMatchB = searchRegex.exec(datasetNameB);
-            if (nameMatchB) {
-              nameMatchesB++;
-              totalNameIdxB += nameMatchB.index;
-            }
-            const tableMatchB = searchRegex.exec(tableNameB);
-            if (tableMatchB) {
-              tableMatchesB++;
-            }
-          });
-          const avgNameIdxA = nameMatchesA ? (totalNameIdxA / nameMatchesA) : datasetNameA.length;
-          const avgNameIdxB = nameMatchesB ? (totalNameIdxB / nameMatchesB) : datasetNameB.length;
-
-          if (nameMatchesA != nameMatchesB) {
-            return nameMatchesB - nameMatchesA;
-          } else if (tableMatchesA != tableMatchesB) {
-            return tableMatchesB - tableMatchesA;
-          } else {
-            return avgNameIdxA - avgNameIdxB; // earlier avg index is better
-          }
-        });
-      case 'A to Z':
-        return sorted.sort((a, b) => (a.menu3 || '').localeCompare(b.menu3 || ''));
-      case 'Z to A':
-        return sorted.sort((a, b) => (b.menu3 || '').localeCompare(a.menu3 || ''));
-      case 'Newest First':
-        return sorted.sort((a, b) => {
-          const keyA = parseUpdatedForSort(a.updated);
-          const keyB = parseUpdatedForSort(b.updated);
-          return keyB.localeCompare(keyA);
-        });
-      case 'Oldest First':
-        return sorted.sort((a, b) => {
-          const keyA = parseUpdatedForSort(a.updated);
-          const keyB = parseUpdatedForSort(b.updated);
-          return keyA.localeCompare(keyB);
-        });
-      default:
-        return sorted;
-    }
+    return sortDatasets({searchQuery, datasets: displayDatasets, sortOrder: sortBy });
   }, [displayDatasets, sortBy, searchQuery]);
 
   const renderHighlightedText = (text, datasetId, key) => {

--- a/src/utils/manageDatasets.js
+++ b/src/utils/manageDatasets.js
@@ -1,0 +1,239 @@
+/**
+ * Filters the given list of datasets based on the filtering criteria provided. Returns a new list of filtered data
+ * 
+ * @param {object} options The argument passed to the function. An object with several fields
+ * @param {list} options.datasets The base list of datasets to filter
+ * @param {list[string]} options.sources The list of sources. Datasets containing any source from the list will be included
+ * @param {list[string]} options.categories The list of categories (menu1s). Datasets with any of the categories will be included
+ * @param {list[string]} options.subcategories The list of subcategories (menu2s). Datasets with any of the sub-cats will be included
+ * @param {string} options.searchQuery The search query the user searched for. Will be broken into individual terms. matches table_name and dataset name
+ * @param {boolean} options.shouldRemoveDupes Whether to remove datasets that share the same table_name from the return list
+ * @returns A filtered list of dataset using all the filtering criteria provided
+ */
+export function filterDatasets({
+  datasets = [],
+  sources = [],
+  categories = [],
+  subcategories = [],
+  searchQuery = '',
+  shouldRemoveDupes = true,
+}) {
+  let filtered = datasets || [];
+
+  // check if any source in the dataset is a selected source
+  // datasets with multiple sources are separated with '; '
+  if (sources.length > 0) {
+    filtered = filtered.filter(d => {
+      return d.source && d.source.split('; ').some(source => sources.includes(source));
+    });
+  }
+
+  // check if the category or subcategory match for each dataset
+  if (categories.length > 0 || subcategories.length > 0) {
+    filtered = filtered.filter(d => categories.includes(d.menu1) || subcategories.includes(d.menu2));
+  }
+
+  if (searchQuery.trim()) {
+    // break query into individual tokens, filter empty tokens, escape special characters
+    const query = searchQuery.trim();
+    const searchTokens = query.split(" ").filter(st => !!st).map(st => st.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+
+    filtered = filtered.filter((dataset) => {
+      const tableName = dataset.table_name || '';
+      const datasetName = dataset.menu3 || '';
+
+      const tableNameMatch = searchTokens.some(searchTerm => {
+        const searchRegex = new RegExp(searchTerm, 'i');
+        return searchRegex.test(tableName);
+      });
+
+      const datasetNameMatch = searchTokens.some(searchTerm => {
+        const searchRegex = new RegExp(searchTerm, 'i');
+        return searchRegex.test(datasetName);
+      });
+
+      return tableNameMatch || datasetNameMatch;
+    });
+  }
+
+  // remove the duplicate datasets using table_name to identify duplicates
+  // only if the user passes the shouldRemoveDupes flag
+  const dupesRemoved = [];
+  if (shouldRemoveDupes) {
+    const seenDatasets = new Set();
+    filtered.forEach(dataset => {
+      if (!seenDatasets.has(dataset.table_name)) {
+        dupesRemoved.push(dataset);
+        seenDatasets.add(dataset.table_name);
+      }
+    });
+  }
+  filtered = shouldRemoveDupes ? dupesRemoved : filtered;
+
+  return filtered;
+}
+
+
+/**
+ * Creates and returns an object containing a mapping of dataset ids to the highlighted text in each dataset. 
+ * 
+ * @param {object} options The argument passed to the function. An object with several fields
+ * @param {list} options.datasets A list of dataset to set the highlighted text for.
+ * @param {string} options.searchQuery The base query string the user is searching for. Used to find matches
+ * 
+ * @returns A map of dataset ids to the highlighted indices of text for those datasets.
+ *          Highlights in the list for a dataset id are tagged with a key of 'table_name' or 'menu3'.
+ */
+export function highlightDatasets({ datasets = [], searchQuery = '' }) {
+  const highlights = {};
+
+  if (searchQuery.trim()) {
+    // break query into individual tokens, filter empty tokens, escape special characters
+    const query = searchQuery.trim();
+    let searchTokens = query.split(" ").filter(st => !!st).map(st => st.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    searchTokens = [...new Set(searchTokens)];
+
+    datasets.forEach(dataset => {
+      const tableName = dataset.table_name || '';
+      const datasetName = dataset.menu3 || '';
+
+      const tableNameMatch = searchTokens.some(searchTerm => {
+        const searchRegex = new RegExp(searchTerm, 'i');
+        return searchRegex.test(tableName);
+      });
+
+      const datasetNameMatch = searchTokens.some(searchTerm => {
+        const searchRegex = new RegExp(searchTerm, 'i');
+        return searchRegex.test(datasetName);
+      });
+
+      // manage the highlights
+      if (tableNameMatch || datasetNameMatch) {
+        const datasetId = dataset.seq_id || dataset.id;
+        highlights[datasetId] = [];
+        
+        if (tableNameMatch) {
+          searchTokens.forEach(searchTerm => {
+            const highlightRegex = new RegExp(searchTerm, 'gi');
+            tableName.replace(highlightRegex, (matched, offset) => {
+              const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'table_name' && hl.indices.find(i => i[0] == offset));
+              if (!alreadyMatched) {
+                highlights[datasetId].push({
+                  key: 'table_name',
+                  indices: [[offset, offset + matched.length - 1]]
+                });
+              }
+            });
+          });
+        }
+        
+        if (datasetNameMatch) {
+          searchTokens.forEach(searchTerm => {
+            const highlightRegex = new RegExp(searchTerm, 'gi');
+            datasetName.replace(highlightRegex, (matched, offset) => {
+              const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'menu3' && hl.indices.find(i => i[0] == offset));
+              if (!alreadyMatched) {
+                highlights[datasetId].push({
+                  key: 'menu3',
+                  indices: [[offset, offset + matched.length - 1]]
+                });
+              }
+            });
+          });
+        }
+      }
+    });
+  }
+
+  return highlights;
+}
+
+
+/**
+ * Sorts the given datasets based on the criteria provided. Returns a new list, doesn't mutate the given datasets. 
+ * 
+ * @param {object} options The argument passed to the function. An object with several fields
+ * @param {list} options.datasets The list of datasets to sort
+ * @param {string} options.sortOrder The way to sort the datasets. One of: 'Relevance', 'A to Z', 'Z to A', 'Oldest First', or 'Newest First'
+ * @param {string} options.searchQuery The base query the user has searched for. Only used when sortOrder is 'Relevance'
+ * @returns A sorted list of datasets based on the sort criteria provided
+ */
+export function sortDatasets({ datasets = [], sortOrder = 'Relevance', searchQuery = ''}) {
+  const sorted = [...datasets]; // create copy since sorting mutates
+  
+  let sortType = sortOrder;
+  // default from relevance to A -> Z if no search
+  const trimmedSearch = searchQuery.trim();
+  if (!trimmedSearch && sortType === 'Relevance') {
+    sortType = 'A to Z';
+  }
+  
+  switch (sortType) {
+    case 'Relevance':
+      const searchTokens = trimmedSearch.split(" ").filter(st => !!st).map(st => st.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+      // Count number to table_name and dataset name (menu3) matches
+      // prioritize higher number of matches and earlier avg index of terms
+      return sorted.sort((a, b) => {
+        const datasetNameA = a.menu3 || '';
+        const tableNameA = a.table_name || '';
+        let nameMatchesA = 0;
+        let totalNameIdxA = 0;
+        let tableMatchesA = 0;
+
+        const datasetNameB = b.menu3 || '';
+        const tableNameB = b.table_name || '';
+        let nameMatchesB = 0;
+        let totalNameIdxB = 0;
+        let tableMatchesB = 0;
+        searchTokens.forEach(searchTerm => {
+          const searchRegex = new RegExp(searchTerm, 'i');
+          const nameMatchA = searchRegex.exec(datasetNameA);
+          if (nameMatchA) {
+            nameMatchesA++;
+            totalNameIdxA += nameMatchA.index;
+          }
+          const tableMatchA = searchRegex.exec(tableNameA);
+          if (tableMatchA) {
+            tableMatchesA++;
+          }
+          const nameMatchB = searchRegex.exec(datasetNameB);
+          if (nameMatchB) {
+            nameMatchesB++;
+            totalNameIdxB += nameMatchB.index;
+          }
+          const tableMatchB = searchRegex.exec(tableNameB);
+          if (tableMatchB) {
+            tableMatchesB++;
+          }
+        });
+        const avgNameIdxA = nameMatchesA ? (totalNameIdxA / nameMatchesA) : datasetNameA.length;
+        const avgNameIdxB = nameMatchesB ? (totalNameIdxB / nameMatchesB) : datasetNameB.length;
+
+        if (nameMatchesA != nameMatchesB) {
+          return nameMatchesB - nameMatchesA;
+        } else if (tableMatchesA != tableMatchesB) {
+          return tableMatchesB - tableMatchesA;
+        } else {
+          return avgNameIdxA - avgNameIdxB; // earlier avg index is better
+        }
+      });
+    case 'A to Z':
+      return sorted.sort((a, b) => (a.menu3 || '').localeCompare(b.menu3 || ''));
+    case 'Z to A':
+      return sorted.sort((a, b) => (b.menu3 || '').localeCompare(a.menu3 || ''));
+    case 'Newest First':
+      return sorted.sort((a, b) => {
+        const keyA = parseUpdatedForSort(a.updated);
+        const keyB = parseUpdatedForSort(b.updated);
+        return keyB.localeCompare(keyA);
+      });
+    case 'Oldest First':
+      return sorted.sort((a, b) => {
+        const keyA = parseUpdatedForSort(a.updated);
+        const keyB = parseUpdatedForSort(b.updated);
+        return keyA.localeCompare(keyB);
+      });
+    default:
+      return sorted;
+  }
+}


### PR DESCRIPTION
There was a lot of duplicated code related to dataset searching/filtering/sorting/highlighting that was split between the home page and the dataset browser page. This PR moves all that duplicated code to a shared util file that is now used instead. 

I wanted to get this cleaned up before I start on any enhancements to how we search for things