### PR TITLE
Another enhancement to search relevance behavior

### DIFF
--- a/src/pages/BrowserPage.jsx
+++ b/src/pages/BrowserPage.jsx
@@ -534,6 +534,11 @@ const BrowserPage = () => {
 
   // filter datasets and set highlights whenever the filter criteria change
   useEffect(() => {
+    // reset the scroll height whenever the user changes the search or filter
+    if (datasetGridRef.current) {
+      datasetGridRef.current.scrollTop = 0;
+    }
+
     // filter based on category, subcategory, sources, and search terms. Also remove duplicates by table_name
     const filtered = filterDatasets({
       datasets,

--- a/src/utils/manageDatasets.js
+++ b/src/utils/manageDatasets.js
@@ -42,12 +42,12 @@ export function filterDatasets({
       const tableName = dataset.table_name || '';
       const datasetName = dataset.menu3 || '';
 
-      const tableNameMatch = searchTokens.some(searchTerm => {
+      const tableNameMatch = searchTokens.every(searchTerm => {
         const searchRegex = new RegExp(searchTerm, 'i');
         return searchRegex.test(tableName);
       });
 
-      const datasetNameMatch = searchTokens.some(searchTerm => {
+      const datasetNameMatch = searchTokens.every(searchTerm => {
         const searchRegex = new RegExp(searchTerm, 'i');
         return searchRegex.test(datasetName);
       });
@@ -212,12 +212,9 @@ export function sortDatasets({ datasets = [], sortOrder = 'Relevance', searchQue
         const avgNameIdxA = nameMatchesA ? (totalNameIdxA / nameMatchesA) : datasetNameA.length;
         const avgNameIdxB = nameMatchesB ? (totalNameIdxB / nameMatchesB) : datasetNameB.length;
 
-        if (nameMatchesA != nameMatchesB) {
-          return nameMatchesB - nameMatchesA;
-        } else if (tableMatchesA != tableMatchesB) {
+        if (tableMatchesA != tableMatchesB) {
           return tableMatchesB - tableMatchesA;
-        } else if (datasetContainsByA || datasetContainsByB) {
-          if (datasetContainsByA && datasetContainsByB) return 0;
+        } else if (datasetContainsByA !== datasetContainsByB) {
           return datasetContainsByA ? 1 : -1;
         } else {
           return avgNameIdxA - avgNameIdxB; // earlier avg index is better


### PR DESCRIPTION
This PR:

- adds back in the reset to scroll position when the users changes filter criteria (it was accidentally removed when I refactored search behavior to a util file).
- updates search to be an AND of search terms instead of an OR