### PR TITLE
Refine the download functionality on the dataset page

### DIFF
--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -271,6 +271,17 @@
     font-size: 14px;
     justify-content: end;
     align-items: flex-start;
+
+    .button.file-button {
+      background: linear-gradient(90deg, #64c08d, #5aba8c);
+      font-size: $font_size-xsmall;
+      color: #fff;
+      padding: 6px 12px;
+      border-radius: 5px;
+      border: none;
+      cursor: pointer;
+      font-weight: 500;
+    }
   }
 
   .download-should-filter-checkbox-container {
@@ -288,6 +299,284 @@
     cursor: pointer;
     accent-color: $color_brand-secondary;
     margin-top: 4px;
+  }
+
+  .download-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.42);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+  }
+
+  .download-modal {
+    width: min(560px, calc(100vw - 30px));
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+    overflow: hidden;
+  }
+
+  .download-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 16px;
+    border-bottom: 1px solid rgba($color_font-medium, 0.25);
+
+    h3 {
+      margin: 0;
+      font-size: 1rem;
+    }
+
+    .close-button {
+      border: none;
+      background: transparent;
+      color: $color_font-medium;
+      cursor: pointer;
+      font-size: 1.5rem;
+      line-height: 1;
+      padding: 0 4px;
+    }
+  }
+
+  .download-modal-body {
+    padding: 14px 16px;
+    max-height: 60vh;
+    overflow: auto;
+  }
+
+  .download-modal-intro {
+    margin: 0 0 12px;
+    font-size: $font_size-xsmall;
+    color: $color_font-medium;
+  }
+
+  .download-modal-api-more {
+    font-size: $font_size-xsmall;
+    line-height: 1.45;
+    color: $color_font-medium;
+
+    a {
+      color: $color_brand-secondary;
+      font-weight: 600;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+
+      &:hover {
+        color: $color_brand-secondary--dark;
+      }
+    }
+
+    &--bottom {
+      margin: 16px 0 0;
+      padding-top: 14px;
+      border-top: 1px solid rgba($color_font-medium, 0.2);
+    }
+  }
+
+  .download-destination-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
+    margin-bottom: 12px;
+    border-radius: 8px;
+    border: 1px solid rgba($color_font-medium, 0.35);
+    background: rgba($color_bg-medium, 0.18);
+
+    button {
+      border: none;
+      border-radius: 6px;
+      background: transparent;
+      color: $color_font-medium;
+      font-size: $font_size-xsmall;
+      font-weight: 600;
+      padding: 8px 12px;
+      cursor: pointer;
+      transition: background-color .14s, color .14s, box-shadow .14s;
+
+      &:hover {
+        color: $color_font-dark;
+      }
+
+      &.is-active {
+        background: rgba($color_brand-secondary, 0.18);
+        color: $color_brand-secondary--dark;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+      }
+    }
+  }
+
+  .download-header-switch-wrapper {
+    margin-top: 10px;
+
+    .download-option-note {
+      margin-top: 0;
+      margin-bottom: 6px;
+    }
+  }
+
+  .download-option-group.download-data-scope--inactive {
+    opacity: 0.58;
+    border-color: rgba($color_font-medium, 0.2);
+    background: rgba($color_font-medium, 0.06);
+
+    legend {
+      color: rgba($color_font-medium, 0.85);
+    }
+
+    .download-option-note {
+      color: rgba($color_font-medium, 0.9);
+    }
+  }
+
+  .download-data-scope-label--disabled {
+    cursor: not-allowed;
+    color: rgba($color_font-medium, 0.9);
+  }
+
+  .download-option-group {
+    border: 1px solid rgba($color_font-medium, 0.25);
+    border-radius: 6px;
+    padding: 10px 12px 12px;
+    margin: 0 0 12px;
+
+    legend {
+      font-weight: 600;
+      font-size: $font_size-xsmall;
+      padding: 0 4px;
+    }
+
+    label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 8px 0 0;
+      font-size: $font_size-xsmall;
+    }
+
+    select {
+      width: 100%;
+      margin-top: 8px;
+      font-size: $font_size-xsmall;
+      border: 1px solid $color_font-medium;
+      border-radius: 4px;
+      padding: 7px 9px;
+      background: #fff;
+    }
+  }
+
+  .download-inline-checkbox {
+    margin-top: 10px;
+  }
+
+  .download-option-note {
+    margin: 8px 0 0;
+    font-size: 11px;
+    color: $color_font-medium;
+    line-height: 1.45;
+  }
+
+  .download-api-endpoint-section {
+    margin-top: 4px;
+  }
+
+  .download-api-endpoint-status {
+    margin-top: 8px;
+    color: $color_brand-secondary--dark;
+    font-weight: 600;
+  }
+
+  .download-endpoint-field {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid rgba($color_font-medium, 0.45);
+    border-radius: 8px;
+    background: #fff;
+    overflow: hidden;
+  }
+
+  .download-endpoint-field-body {
+    flex: 1;
+    min-width: 0;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .download-endpoint-field-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: rgba($color_font-medium, 0.95);
+    line-height: 1.2;
+  }
+
+  .download-endpoint-field-url {
+    font-size: 13px;
+    color: $color_font-dark;
+    line-height: 1.45;
+    word-break: break-all;
+    max-height: 120px;
+    overflow-y: auto;
+    padding-right: 2px;
+  }
+
+  .download-endpoint-field-copy {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    min-height: 100%;
+    padding: 0;
+    border: none;
+    border-left: 1px solid rgba($color_font-medium, 0.2);
+    background: rgba($color_bg-medium, 0.2);
+    color: $color_font-dark;
+    cursor: pointer;
+    transition: background-color .14s, color .14s;
+
+    &:hover {
+      background: rgba($color_brand-secondary, 0.1);
+      color: $color_brand-secondary--dark;
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: inset 0 0 0 2px rgba($color_brand-secondary, 0.35);
+    }
+  }
+
+  .download-modal-footer {
+    border-top: 1px solid rgba($color_font-medium, 0.25);
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 16px;
+
+    .button {
+      border-radius: 5px;
+      padding: 6px 12px;
+      border: 1px solid rgba($color_font-medium, 0.4);
+      background: #fff;
+      cursor: pointer;
+    }
+
+    .button.file-button {
+      border: none;
+      color: #fff;
+      background: linear-gradient(90deg, #64c08d, #5aba8c);
+      transition: background 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .button.file-button.download-modal-primary--copied {
+      background: linear-gradient(90deg, #4a9d6e, #3d8f65);
+      box-shadow: 0 0 0 2px rgba(100, 192, 141, 0.45);
+    }
   }
 
   .table-wrapper { 

--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -1,151 +1,7 @@
-import React, { useState, useRef, useEffect, useMemo } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import { formatUpdated } from "../../utils/formatUpdated";
-
-const formats = {
-  csv: {
-    extension: ".csv",
-    isGeospatial: true,
-    isTabular: true,
-    zoningAtlas: "https://mapc365.sharepoint.com/:x:/s/DataServicesSP/Efonrnmw_kdMhmG3Dw2BkTcBIpe2sC_2ADWTWfUjOs4JhQ?e=K65BCE",
-    displayName: "CSV",
-  },
-  json: {
-    extension: ".json",
-    isGeospatial: false,
-    isTabular: true,
-    zoningAtlas: "",
-    displayName: "JSON",
-  },
-  shapefile: {
-    extension: ".shp",
-    isGeospatial: true,
-    isTabular: false,
-    zoningAtlas: "https://mapc365.sharepoint.com/:f:/s/DataServicesSP/ErKkXSLH_iBOlDhJrTXldrYBIIZ4ZXe4Bkw7OyVapVpX3Q?e=iRkWVB",
-    displayName: "ESRI Shapefile",
-  },
-  geojson: {
-    extension: ".geojson",
-    isGeospatial: true,
-    isTabular: false,
-    zoningAtlas: "",
-    displayName: "GeoJSON",
-  },
-};
-
-/**
- * Downloads metadata in CSV format
- * @param {Event} e - The event object
- * @param {string} database - The database name
- * @param {Object} metadata - The metadata object
- * @param {string} title - The title of the dataset
- * @param {string} table - The table name
- * @param {string} description - The description of the dataset
- */
-const downloadMetadata = (e, database, metadata, title, table = "", description = "") => {
-  // TODO: Make this a cached download from the server as well
-  e.preventDefault();
-  const documentHeader = ["name", "alias", "details"];
-  let rows;
-  if (database === "towndata" || database === "gisdata") {
-    const metadataName = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => (attr.attrlabl ? attr.attrlabl : "undefined"));
-    const metadataAlias = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => attr.attalias);
-    const metadataDescription = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => (attr.attrdef ? attr.attrdef : "undefined"));
-    rows = [
-      ["title", "Title", title],
-      ["tbl_table", "Table", table],
-      ["descriptn", "Description", description],
-    ].concat(metadataName.map((item, i) => [item, metadataAlias[i], metadataDescription[i]]));
-  } else {
-    const values = metadata.map((row) => documentHeader.map((key) => row[key]));
-    rows = values.map((row) => row.reduce((a, b) => `${a},${b}`));
-  }
-  const csvHeader = "data:text/csv;charset=utf-8,";
-  const documentRows = rows.reduce((a, b) => `${a}\n${b}`);
-
-  const documentStructure = [[documentHeader], documentRows].reduce((a, b) => a.concat(b));
-  const documentBody = documentStructure.reduce((a, b) => `${a}\n${b}`);
-
-  const csvFile = csvHeader + documentBody;
-  const encoded = encodeURI(csvFile);
-  const fileName = `${title}-metadata.csv`;
-
-  const link = document.createElement("a");
-  link.setAttribute("href", encoded);
-  link.setAttribute("download", fileName);
-
-  document.body.appendChild(link);
-  link.click();
-};
-
-const urlForDownload = (
-  schema, table, database, selectedYears, queryYearColumn, selectedColumns, columnKeys, selectedGeographies, availableGeographies, geographyColumn, filterExportData, format
-) => {
-  let url = "#";
-
-  // Handle zoning atlas special case
-  if (table === "zoning_atlas") {
-    return formats[format].zoningAtlas || "#";
-  }
-
-  // Build query and fetch data based on whether years are selected
-  url = `/api/export?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${database}&schema=${schema}&table=${table}&format=${format}`;
-  // TODO: Should the filter export checkbox apply to years too?
-  if (selectedYears.length > 0 && queryYearColumn !== "") {
-    url = `${url}&years=${selectedYears.join(",")}`;
-  }
-
-  // Include all columns by default if the users hasn't de-selected any
-  // Respect the checkbox for if data should be filtered
-  if (selectedColumns.length && selectedColumns.length !== columnKeys.length && filterExportData) {
-    url = `${url}&columns=${selectedColumns.join(',')}`
-  }
-
-  // Include all geographies by default if the users hasn't de-selected any
-  // Respect the checkbox for if data should be filtered
-  if (selectedGeographies.length && selectedGeographies.length !== availableGeographies.length && geographyColumn && filterExportData) {
-    // Some geographies have the "&" character, need to be encoded
-    const mappedGeos = selectedGeographies.map(col => encodeURIComponent(col));
-    url = `${url}&geographies=${mappedGeos.join(',')}&geoColumn=${geographyColumn}`
-  }
-
-  return url;
-};
-
-const setDownloadButton = (
-  metadata, schema, table, title, description, selectedYears, queryYearColumn, selectedColumns, columnKeys, selectedGeographies, availableGeographies, geographyColumn, filterExportData, database
-) => {
-  const tableIsGeospatial = database === "towndata" || database === "gisdata";
-  return (
-    <div className="details-content-column download-links">
-      Download:
-      <div className="download-buttons">
-        <div className="button file-button" onClick={(e) => downloadMetadata(e, database, metadata, title, table, description)}>
-          .metadata
-        </div>
-        {Object.entries(formats)
-          .filter(([format, config]) => config.isGeospatial === tableIsGeospatial || (!tableIsGeospatial && config.isTabular)) // eslint-disable-line no-unused-vars
-          .map(([format, config]) => (
-            <a
-              key={format}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={`Download data as ${config.displayName}`}
-              download
-              className="button file-button"
-              href={
-                urlForDownload(
-                  schema, table, database, selectedYears, queryYearColumn, selectedColumns, columnKeys, selectedGeographies, availableGeographies, geographyColumn, filterExportData, format
-                )
-              }
-            >
-              {config.extension}
-            </a>
-          ))}
-      </div>
-    </div>
-  );
-};
+import ExportDataModal from "./ExportDataModal";
 
 const setSelectYears = (availableYears, updateSelectedYears, selectedYears) => {
   if (availableYears.length > 0) {
@@ -569,11 +425,7 @@ function DatasetHeader({
   updateSelectedGeographies,
   geographyColumn,
 }) {
-  const [filterExportData, setFilterExportData] = useState(true);
-
-  const showFilterExportCheckbox = useMemo(() => {
-    return columnKeys.length !== selectedColumns.length || availableGeographies.length !== selectedGeographies.length;
-  }, [columnKeys, selectedColumns, selectedColumns.length, availableGeographies, selectedGeographies, selectedGeographies.length]);
+  const [downloadModalOpen, setDownloadModalOpen] = useState(false);
 
   return (
     <div className="page-header">
@@ -612,34 +464,11 @@ function DatasetHeader({
             </div>
           </div>
           <div className="details-content-column download-section">
-            {setDownloadButton(
-              metadata, schema, table, title, description, selectedYears, queryYearColumn, selectedColumns, columnKeys, selectedGeographies, availableGeographies, geographyColumn, filterExportData, database
-            )}
-            {showFilterExportCheckbox && <div className="download-should-filter-checkbox-container">
-              <label title="Should the exported data be filtered using the current selections?">
-                Export filtered data only
-              </label>
-              <input
-                className="download-should-filter-checkbox"
-                type="checkbox"
-                checked={filterExportData}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  setFilterExportData(e.target.checked);
-                }}
-              />
-            </div>}
-            {!!datasetId && (
-              <div style={{ marginTop: "10px", textAlign: "right" }}>
-                <a
-                  href={`/developers?datasetId=${encodeURIComponent(String(datasetId))}`}
-                  className="button feedback-button"
-                  style={{ fontSize: "12px" }}
-                >
-                  Generate API
-                </a>
-              </div>
-            )}
+            <div className="details-content-column download-links">
+              <button type="button" className="button file-button" onClick={() => setDownloadModalOpen(true)}>
+                Export data
+              </button>
+            </div>
             <div style={{ marginTop: "10px", textAlign: "right" }}>
               <a
                 href="https://airtable.com/appqSr3MqAkN1GCfb/pagdcSeY2bc4rblam/form"
@@ -654,6 +483,25 @@ function DatasetHeader({
           </div>
         </div>
       </div>
+      <ExportDataModal
+        isOpen={downloadModalOpen}
+        onClose={() => setDownloadModalOpen(false)}
+        datasetId={datasetId}
+        title={title}
+        table={table}
+        description={description}
+        database={database}
+        schema={schema}
+        metadata={metadata}
+        columnKeys={columnKeys}
+        selectedColumns={selectedColumns}
+        selectedYears={selectedYears}
+        queryYearColumn={queryYearColumn}
+        selectedGeographies={selectedGeographies}
+        availableGeographies={availableGeographies}
+        geographyColumn={geographyColumn}
+        availableYears={availableYears}
+      />
     </div>
   );
 }

--- a/src/components/partials/ExportDataModal.jsx
+++ b/src/components/partials/ExportDataModal.jsx
@@ -1,0 +1,558 @@
+import React, { useState, useEffect, useMemo, useRef } from "react";
+import PropTypes from "prop-types";
+
+const formats = {
+  csv: {
+    extension: ".csv",
+    isGeospatial: true,
+    isTabular: true,
+    zoningAtlas: "https://mapc365.sharepoint.com/:x:/s/DataServicesSP/Efonrnmw_kdMhmG3Dw2BkTcBIpe2sC_2ADWTWfUjOs4JhQ?e=K65BCE",
+    displayName: "CSV",
+  },
+  json: {
+    extension: ".json",
+    isGeospatial: false,
+    isTabular: true,
+    zoningAtlas: "",
+    displayName: "JSON",
+  },
+  shapefile: {
+    extension: ".shp",
+    isGeospatial: true,
+    isTabular: false,
+    zoningAtlas: "https://mapc365.sharepoint.com/:f:/s/DataServicesSP/ErKkXSLH_iBOlDhJrTXldrYBIIZ4ZXe4Bkw7OyVapVpX3Q?e=iRkWVB",
+    displayName: "Shapefile",
+  },
+  geojson: {
+    extension: ".geojson",
+    isGeospatial: true,
+    isTabular: false,
+    zoningAtlas: "",
+    displayName: "GeoJSON",
+  },
+};
+
+const downloadMetadata = (database, metadata, title, table = "", description = "") => {
+  const documentHeader = ["name", "alias", "details"];
+  let rows;
+  if (database === "towndata" || database === "gisdata") {
+    const metadataName = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => (attr.attrlabl ? attr.attrlabl : "undefined"));
+    const metadataAlias = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => attr.attalias);
+    const metadataDescription = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => (attr.attrdef ? attr.attrdef : "undefined"));
+    rows = [
+      ["title", "Title", title],
+      ["tbl_table", "Table", table],
+      ["descriptn", "Description", description],
+    ].concat(metadataName.map((item, i) => [item, metadataAlias[i], metadataDescription[i]]));
+  } else {
+    const values = metadata.map((row) => documentHeader.map((key) => row[key]));
+    rows = values.map((row) => row.reduce((a, b) => `${a},${b}`));
+  }
+  const csvHeader = "data:text/csv;charset=utf-8,";
+  const documentRows = rows.reduce((a, b) => `${a}\n${b}`);
+
+  const documentStructure = [[documentHeader], documentRows].reduce((a, b) => a.concat(b));
+  const documentBody = documentStructure.reduce((a, b) => `${a}\n${b}`);
+
+  const csvFile = csvHeader + documentBody;
+  const encoded = encodeURI(csvFile);
+  const fileName = `${title}-metadata.csv`;
+
+  const link = document.createElement("a");
+  link.setAttribute("href", encoded);
+  link.setAttribute("download", fileName);
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+const urlForDownload = (
+  schema,
+  table,
+  database,
+  selectedYears,
+  queryYearColumn,
+  selectedColumns,
+  columnKeys,
+  selectedGeographies,
+  availableGeographies,
+  geographyColumn,
+  downloadScope,
+  format,
+  useMetadataColumns
+) => {
+  let url = "#";
+
+  if (table === "zoning_atlas") {
+    return formats[format].zoningAtlas || "#";
+  }
+
+  url = `/api/export?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${database}&schema=${schema}&table=${table}&format=${format}`;
+  const shouldUseFilteredValues = downloadScope === "filtered";
+  if (shouldUseFilteredValues && selectedYears.length > 0 && queryYearColumn !== "") {
+    url = `${url}&years=${selectedYears.join(",")}`;
+  }
+
+  if (shouldUseFilteredValues && selectedColumns.length && selectedColumns.length !== columnKeys.length) {
+    url = `${url}&columns=${selectedColumns.join(",")}`;
+  }
+
+  if (shouldUseFilteredValues && selectedGeographies.length && selectedGeographies.length !== availableGeographies.length && geographyColumn) {
+    const mappedGeos = selectedGeographies.map((col) => encodeURIComponent(col));
+    url = `${url}&geographies=${mappedGeos.join(",")}&geoColumn=${geographyColumn}`;
+  }
+
+  if (["csv", "json", "geojson"].includes(format)) {
+    url = `${url}&useMetadataColumns=${useMetadataColumns ? "true" : "false"}`;
+  }
+
+  return url;
+};
+
+const toAbsoluteExportUrl = (url) => {
+  if (!url || url === "#") {
+    return url;
+  }
+  if (/^https?:\/\//i.test(url)) {
+    return url;
+  }
+  if (typeof window !== "undefined" && window.location?.origin) {
+    try {
+      return new URL(url, window.location.origin).href;
+    } catch {
+      return url;
+    }
+  }
+  return url;
+};
+
+/** Start file download without opening a new tab (avoids a blank window from window.open). */
+const triggerExportFileDownload = (url) => {
+  if (!url || url === "#") {
+    return;
+  }
+  const link = document.createElement("a");
+  link.href = /^https?:\/\//i.test(url) ? url : toAbsoluteExportUrl(url);
+  link.rel = "noopener noreferrer";
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+const getDownloadFormatOptions = (database) => {
+  const tableIsGeospatial = database === "towndata" || database === "gisdata";
+  return Object.entries(formats).filter(
+    ([, config]) => config.isGeospatial === tableIsGeospatial || (!tableIsGeospatial && config.isTabular),
+  );
+};
+
+function ExportDataModal({
+  isOpen,
+  onClose,
+  datasetId,
+  title = "",
+  table = "",
+  description = "",
+  database = "ds",
+  schema = "",
+  metadata = [],
+  columnKeys = [],
+  selectedColumns = [],
+  selectedYears = [],
+  queryYearColumn = "",
+  selectedGeographies = [],
+  availableGeographies = [],
+  geographyColumn,
+  availableYears = [],
+}) {
+  const [exportTarget, setExportTarget] = useState("data");
+  const [downloadDestination, setDownloadDestination] = useState("file");
+  const [downloadScope, setDownloadScope] = useState("filtered");
+  const [downloadFormat, setDownloadFormat] = useState("csv");
+  const [useMetadataColumns, setUseMetadataColumns] = useState(true);
+  const [apiCopyStatus, setApiCopyStatus] = useState("");
+  const [justCopiedEndpoint, setJustCopiedEndpoint] = useState(false);
+  const copyEndpointFeedbackTimerRef = useRef(null);
+
+  const availableDownloadFormats = useMemo(() => getDownloadFormatOptions(database), [database]);
+  const isShapefileSelection = downloadFormat === "shapefile";
+
+  const hasFilteredSelections = useMemo(() => {
+    const yearsAreFiltered = queryYearColumn && selectedYears.length > 0 && selectedYears.length !== availableYears.length;
+    const columnsAreFiltered = columnKeys.length > 0 && selectedColumns.length !== columnKeys.length;
+    const geographiesAreFiltered =
+      availableGeographies.length > 0 && selectedGeographies.length !== availableGeographies.length;
+    return yearsAreFiltered || columnsAreFiltered || geographiesAreFiltered;
+  }, [
+    queryYearColumn,
+    selectedYears,
+    availableYears.length,
+    columnKeys.length,
+    selectedColumns.length,
+    availableGeographies.length,
+    selectedGeographies.length,
+  ]);
+
+  useEffect(() => {
+    if (!availableDownloadFormats.length) {
+      return;
+    }
+    const selectedIsAvailable = availableDownloadFormats.some(([format]) => format === downloadFormat);
+    if (!selectedIsAvailable) {
+      setDownloadFormat(availableDownloadFormats[0][0]);
+    }
+  }, [availableDownloadFormats, downloadFormat]);
+
+  useEffect(() => {
+    if (!hasFilteredSelections) {
+      setDownloadScope("all");
+    }
+  }, [hasFilteredSelections]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setExportTarget("data");
+    setDownloadDestination("file");
+    setDownloadScope(hasFilteredSelections ? "filtered" : "all");
+    setApiCopyStatus("");
+    setJustCopiedEndpoint(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  useEffect(
+    () => () => {
+      if (copyEndpointFeedbackTimerRef.current) {
+        window.clearTimeout(copyEndpointFeedbackTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (downloadDestination !== "api" || exportTarget !== "data") {
+      setJustCopiedEndpoint(false);
+      if (copyEndpointFeedbackTimerRef.current) {
+        window.clearTimeout(copyEndpointFeedbackTimerRef.current);
+        copyEndpointFeedbackTimerRef.current = null;
+      }
+    }
+  }, [downloadDestination, exportTarget]);
+
+  const getConfiguredExportUrl = (scopeOverride = downloadScope, formatOverride = downloadFormat) =>
+    urlForDownload(
+      schema,
+      table,
+      database,
+      selectedYears,
+      queryYearColumn,
+      selectedColumns,
+      columnKeys,
+      selectedGeographies,
+      availableGeographies,
+      geographyColumn,
+      scopeOverride,
+      formatOverride,
+      useMetadataColumns,
+    );
+
+  const copyApiEndpoint = () => {
+    const effectiveDownloadScope = isShapefileSelection ? "all" : downloadScope;
+    const apiUrl = toAbsoluteExportUrl(getConfiguredExportUrl(effectiveDownloadScope));
+    if (!apiUrl || apiUrl === "#") {
+      setApiCopyStatus("Nothing to copy.");
+      setJustCopiedEndpoint(false);
+      return;
+    }
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard
+        .writeText(apiUrl)
+        .then(() => {
+          setApiCopyStatus("API endpoint copied!");
+          setJustCopiedEndpoint(true);
+          if (copyEndpointFeedbackTimerRef.current) {
+            window.clearTimeout(copyEndpointFeedbackTimerRef.current);
+          }
+          copyEndpointFeedbackTimerRef.current = window.setTimeout(() => {
+            setJustCopiedEndpoint(false);
+            copyEndpointFeedbackTimerRef.current = null;
+          }, 2200);
+        })
+        .catch(() => {
+          setJustCopiedEndpoint(false);
+          setApiCopyStatus("Could not copy. Try selecting the URL or use Copy endpoint below.");
+        });
+    } else {
+      setApiCopyStatus("Copy not available in this browser.");
+      setJustCopiedEndpoint(false);
+    }
+  };
+
+  const handleDownloadSubmit = () => {
+    if (exportTarget === "metadata") {
+      downloadMetadata(database, metadata, title, table, description);
+      return;
+    }
+
+    const effectiveDownloadScope = isShapefileSelection ? "all" : downloadScope;
+
+    if (downloadDestination === "api") {
+      copyApiEndpoint();
+      return;
+    }
+
+    const downloadUrl = getConfiguredExportUrl(effectiveDownloadScope);
+    triggerExportFileDownload(downloadUrl);
+  };
+
+  const resolvedApiExportUrl =
+    isOpen && exportTarget === "data" && downloadDestination === "api"
+      ? toAbsoluteExportUrl(getConfiguredExportUrl(isShapefileSelection ? "all" : downloadScope))
+      : "";
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="download-modal-overlay" role="presentation" onClick={onClose}>
+      <div
+        className="download-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Export data"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="download-modal-header">
+          <h3>Export data</h3>
+          <button type="button" className="close-button" onClick={onClose} aria-label="Close export dialog">
+            ×
+          </button>
+        </div>
+        <div className="download-modal-body">
+          <>
+            <fieldset className="download-option-group">
+              <legend>What to export</legend>
+              <div className="download-destination-switch" role="tablist" aria-label="Export content">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={exportTarget === "data"}
+                  className={exportTarget === "data" ? "is-active" : ""}
+                  onClick={() => setExportTarget("data")}
+                >
+                  Dataset data
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={exportTarget === "metadata"}
+                  className={exportTarget === "metadata" ? "is-active" : ""}
+                  onClick={() => setExportTarget("metadata")}
+                >
+                  Metadata
+                </button>
+              </div>
+              <p className="download-option-note">
+                {exportTarget === "data"
+                  ? "Export table rows in the selected file format."
+                  : "Download a CSV file that describes the dataset columns (names, aliases, and descriptions) — no data included."}
+              </p>
+            </fieldset>
+
+            {exportTarget === "data" && (
+              <>
+                <fieldset className="download-option-group">
+                  <legend>File format</legend>
+                  <p className="download-option-note">Choose the type of file.</p>
+                  <select value={downloadFormat} onChange={(e) => setDownloadFormat(e.target.value)}>
+                    {availableDownloadFormats.map(([format, config]) => (
+                      <option key={format} value={format}>
+                        {config.displayName}
+                      </option>
+                    ))}
+                  </select>
+                  {["csv", "json"].includes(downloadFormat) && (
+                    <div className="download-header-switch-wrapper">
+                      <p className="download-option-note">Choose a column header style</p>
+                      <div className="download-destination-switch" role="tablist" aria-label="Column header style">
+                        <button
+                          type="button"
+                          role="tab"
+                          aria-selected={useMetadataColumns}
+                          className={useMetadataColumns ? "is-active" : ""}
+                          onClick={() => setUseMetadataColumns(true)}
+                        >
+                          Metadata header
+                        </button>
+                        <button
+                          type="button"
+                          role="tab"
+                          aria-selected={!useMetadataColumns}
+                          className={!useMetadataColumns ? "is-active" : ""}
+                          onClick={() => setUseMetadataColumns(false)}
+                        >
+                          Raw table header
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </fieldset>
+
+                <div className="download-destination-switch" role="tablist" aria-label="Export destination">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={downloadDestination === "file"}
+                    className={downloadDestination === "file" ? "is-active" : ""}
+                    onClick={() => setDownloadDestination("file")}
+                  >
+                    Download file
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={downloadDestination === "api"}
+                    className={downloadDestination === "api" ? "is-active" : ""}
+                    onClick={() => setDownloadDestination("api")}
+                  >
+                    API endpoint
+                  </button>
+                </div>
+
+                {downloadDestination === "api" ? (
+                  <div className="download-api-endpoint-section">
+                    <div className="download-endpoint-field" role="group" aria-label="API endpoint">
+                      <div className="download-endpoint-field-body">
+                        <span className="download-endpoint-field-label">API endpoint</span>
+                        <div className="download-endpoint-field-url">{resolvedApiExportUrl}</div>
+                      </div>
+                      <button
+                        type="button"
+                        className="download-endpoint-field-copy"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          copyApiEndpoint();
+                        }}
+                        aria-label="Copy API endpoint URL"
+                        title="Copy URL"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="20"
+                          height="20"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden
+                        >
+                          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                        </svg>
+                      </button>
+                    </div>
+                    {apiCopyStatus && (
+                      <p className="download-option-note download-api-endpoint-status" role="status" aria-live="polite">
+                        {apiCopyStatus}
+                      </p>
+                    )}
+                  </div>
+                ) : isShapefileSelection ? (
+                  <fieldset className="download-option-group">
+                    <legend>ESRI Shapefile behavior</legend>
+                    <p className="download-option-note">
+                      ESRI Shapefile always downloads the full table. Filtered export is not applied.
+                    </p>
+                  </fieldset>
+                ) : (
+                  <fieldset
+                    className={`download-option-group${!hasFilteredSelections ? " download-data-scope--inactive" : ""}`}
+                    aria-disabled={!hasFilteredSelections}
+                  >
+                    <legend>Data scope</legend>
+                    <label className={!hasFilteredSelections ? "download-data-scope-label--disabled" : undefined}>
+                      <input
+                        type="checkbox"
+                        checked={downloadScope === "filtered"}
+                        disabled={!hasFilteredSelections}
+                        onChange={(e) => setDownloadScope(e.target.checked ? "filtered" : "all")}
+                      />
+                      Export filtered data only
+                    </label>
+                    <p className="download-option-note">
+                      {!hasFilteredSelections
+                        ? "No column, year, or geography filters are applied. Export uses the full table."
+                        : downloadScope === "filtered"
+                          ? "Only current filtered rows will be exported."
+                          : "The full table will be exported."}
+                    </p>
+                  </fieldset>
+                )}
+              </>
+            )}
+
+            {exportTarget === "data" && (
+              <p className="download-modal-api-more download-modal-api-more--bottom">
+                <a
+                  href={datasetId ? `/developers?datasetId=${encodeURIComponent(String(datasetId))}` : "/developers"}
+                >
+                  API documentation
+                </a>{" "}
+                has parameters, code examples, and more detail.
+              </p>
+            )}
+          </>
+        </div>
+        <div className="download-modal-footer">
+          <button type="button" className="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={`button file-button${
+              justCopiedEndpoint && exportTarget === "data" && downloadDestination === "api" ? " download-modal-primary--copied" : ""
+            }`}
+            onClick={handleDownloadSubmit}
+            disabled={exportTarget === "metadata" && (!metadata || (Array.isArray(metadata) && metadata.length === 0))}
+          >
+            {exportTarget === "metadata"
+              ? "Download"
+              : downloadDestination === "api"
+                ? justCopiedEndpoint
+                  ? "Copied!"
+                  : "Copy endpoint"
+                : "Download"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ExportDataModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  datasetId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  title: PropTypes.string,
+  table: PropTypes.string,
+  description: PropTypes.string,
+  database: PropTypes.string,
+  schema: PropTypes.string,
+  metadata: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.objectOf(PropTypes.object)]),
+  columnKeys: PropTypes.arrayOf(PropTypes.object),
+  selectedColumns: PropTypes.arrayOf(PropTypes.string),
+  selectedYears: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  queryYearColumn: PropTypes.string,
+  selectedGeographies: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  availableGeographies: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  geographyColumn: PropTypes.string,
+  availableYears: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+};
+
+export default ExportDataModal;


### PR DESCRIPTION
Make multiple data downloads button into one single Export data window. You pick what to export, file vs API, and other options in one spot instead of hunting for different links.