### PR TITLE
Add updated to gisdata/towndata datasets

### DIFF
--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -174,17 +174,18 @@ class DataViewerClass extends React.Component {
             this.setState({
               availableYears: distinctYears,
               rows: tableResults,
+              description: metadata.documentation.metadata.dataIdInfo.idPurp || "",
               columnKeys: sortedMetadata,
               selectedColumns: sortedMetadata.map((col) => col.name), // Initialize with all columns
               metadata,
               selectedYears: distinctYears.length ? [distinctYears[0]] : [],
-              description: metadata.documentation.metadata.dataIdInfo.idPurp || "",
+              table: dataset.table_name,
               schema: dataset.schemaname,
+              database: dataset.db_name,
+              title: dataset.menu3,
               source: dataset.source,
               queryYearColumn: dataset.yearcolumn,
-              database: dataset.db_name,
-              table: dataset.table_name,
-              title: dataset.menu3,
+              updatedAt: dataset.updated,
               loading: false,
             });
           } catch (error) {


### PR DESCRIPTION
Small fix to ensure that we show the `updated` field when viewing a `gisdata` or `towndata` dataset. 

Also orders the fields in the `setState` call for gisdata/towndata to be in the same order as the `setState` for tabular so it's easier to compare the two cases and see what's different 