### PR TITLE
Adds number of rows selection to data table, remove scroll if rows is 25 or less

### DIFF
--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -229,12 +229,60 @@
       flex: 1 0 66%;
 
       &:last-of-type {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+
         flex: 1 0 23%;
         top: -30px;
 
         margin-left: 2%;
 
         text-align: right;
+      }
+
+      .rows-per-page-selector {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 8px;
+        top: 30px;
+
+        .rows-per-page-label {
+          font-size: $font_size-xsmall;
+          color: $color_font-dark;
+          white-space: nowrap;
+        }
+
+        .rows-per-page-dropdown {
+          padding: 6px 10px;
+          border: 1px solid $color_font-medium;
+          border-radius: $elem_button-radius;
+          background: $color_bg-light;
+          color: $color_font-dark;
+          font-size: $font_size-xsmall;
+          cursor: pointer;
+          transition: border-color .14s, background-color .14s;
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          appearance: none;
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 9L1 4h10z'/%3E%3C/svg%3E");
+          background-repeat: no-repeat;
+          background-position: right 8px center;
+          padding-right: 30px;
+          min-width: 70px;
+
+          &:hover {
+            border-color: $color_brand-secondary;
+            background-color: rgba($color_brand-secondary, 0.05);
+          }
+
+          &:focus {
+            outline: none;
+            border-color: $color_brand-secondary;
+            box-shadow: 0 0 0 2px rgba($color_brand-secondary, 0.2);
+          }
+        }
       }
     }
   }
@@ -990,60 +1038,13 @@
   .table-wrapper { 
     @extend ._partial-bg;
     
-    .table-controls-top {
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-      margin-bottom: 15px;
-      padding: 0 5px;
-
-      .rows-per-page-selector {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-
-        .rows-per-page-label {
-          font-size: $font_size-xsmall;
-          color: $color_font-dark;
-          white-space: nowrap;
-        }
-
-        .rows-per-page-dropdown {
-          padding: 6px 10px;
-          border: 1px solid $color_font-medium;
-          border-radius: $elem_button-radius;
-          background: $color_bg-light;
-          color: $color_font-dark;
-          font-size: $font_size-xsmall;
-          cursor: pointer;
-          transition: border-color .14s, background-color .14s;
-          -webkit-appearance: none;
-          -moz-appearance: none;
-          appearance: none;
-          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M6 9L1 4h10z'/%3E%3C/svg%3E");
-          background-repeat: no-repeat;
-          background-position: right 8px center;
-          padding-right: 30px;
-          min-width: 70px;
-
-          &:hover {
-            border-color: $color_brand-secondary;
-            background-color: rgba($color_brand-secondary, 0.05);
-          }
-
-          &:focus {
-            outline: none;
-            border-color: $color_brand-secondary;
-            box-shadow: 0 0 0 2px rgba($color_brand-secondary, 0.2);
-          }
-        }
-      }
-    }
-    
     .table-container {
-      max-height: 70vh;
       overflow-y: auto;
       overflow-x: auto;
+
+      &.vertical-scroll {
+        max-height: 70vh;
+      }
     }
     
     .sticky-header-table {

--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -429,6 +429,8 @@ function DatasetHeader({
   selectedGeographies = [],
   updateSelectedGeographies,
   geographyColumn,
+  rowsPerPage,
+  updateRowsPerPage,
 }) {
   const location = useLocation();
   const isEmbedView = new URLSearchParams(location.search).get("embed") === "1";
@@ -556,6 +558,23 @@ function DatasetHeader({
                   Export
                 </button>
               </div>
+              <div className="rows-per-page-selector">
+                <label htmlFor="rows-per-page" className="rows-per-page-label">
+                  Rows per page:
+                </label>
+                <select
+                  id="rows-per-page"
+                  className="rows-per-page-dropdown"
+                  value={rowsPerPage}
+                  onChange={(e) => updateRowsPerPage(Number(e.target.value))}
+                >
+                  <option value={10}>10</option>
+                  <option value={25}>25</option>
+                  <option value={50}>50</option>
+                  <option value={100}>100</option>
+                  <option value={500}>500</option>
+                </select>
+              </div>
             </div>
           )}
         </div>
@@ -611,6 +630,8 @@ DatasetHeader.propTypes = {
   geographyColumn: PropTypes.string,
   universe: PropTypes.string,
   updatedAt: PropTypes.string,
+  rowsPerPage: PropTypes.number,
+  updateRowsPerPage: PropTypes.func
 };
 
 export default DatasetHeader;

--- a/src/components/partials/DatasetTable.jsx
+++ b/src/components/partials/DatasetTable.jsx
@@ -140,7 +140,6 @@ class DatasetTable extends React.Component {
       geographyColumn = null,
       linkRowsToDatasetView = false,
       updatePage,
-      updateRowsPerPage
     } = this.props;
     const { sortColumn, sortDirection, inputPageNum } = this.state;
     // Filter columnKeys based on selectedColumns
@@ -189,12 +188,13 @@ class DatasetTable extends React.Component {
     const numOfPages = Math.ceil(dataRows.length / rowsPerPage);
     const backButtonClasses = currentPage === 1 ? "button-wrapper lift disabled" : "button-wrapper lift";
     const forwardButtonClasses = currentPage === numOfPages ? "button-wrapper list disabled" : "button-wrapper lift";
+    const isEmbedView = new URLSearchParams(location.search).get("embed") === "1";
     return (
       <div className="table-wrapper">
         <div className="container tight">
           <div className="scroll-horizontal-rotated ui lift">
             <div className="cancel-rotate">
-              <div className="table-container">
+              <div className={`table-container${!isEmbedView && rowsPerPage <= 25 ? "" : " vertical-scroll"}`}>
                 <table className="ui sortable unstackable selectable compact table ember-view sticky-header-table">
                   <thead className="sticky-header">
                     <tr>{renderedHeaders}</tr>
@@ -288,7 +288,6 @@ DatasetTable.propTypes = {
   geographyColumn: PropTypes.string,
   linkRowsToDatasetView: PropTypes.bool,
   updatePage: PropTypes.func.isRequired,
-  updateRowsPerPage: PropTypes.func.isRequired,
 };
 
 export default DatasetTable;

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -303,6 +303,8 @@ class DataViewerClass extends React.Component {
             selectedGeographies={this.state.selectedGeographies}
             updateSelectedGeographies={this.updateSelectedGeographies}
             geographyColumn={this.state.geographyColumn}
+            rowsPerPage={this.state.rowsPerPage}
+            updateRowsPerPage={this.updateRowsPerPage}
             source={this.state.source}
             table={this.state.table}
             title={this.state.title}
@@ -323,7 +325,6 @@ class DataViewerClass extends React.Component {
             geographyColumn={this.state.geographyColumn}
             linkRowsToDatasetView={this.state.linkInventoryRows}
             updatePage={this.updatePage}
-            updateRowsPerPage={this.updateRowsPerPage}
             metadata={this.state.metadata}
           />
         </section>


### PR DESCRIPTION
Adds the selector for the number of rows into the dataset view page's header. Allows the user to select up to 500 rows (so all munis can be seen at once). 

Also removes the scrolling functionality of the dataset viewer if the user is viewing 25 rows or less. 