### PR TITLE
Change compressed dataset cards to tabs

### DIFF
--- a/src/pages/BrowserPage.jsx
+++ b/src/pages/BrowserPage.jsx
@@ -1084,9 +1084,14 @@ const BrowserPage = () => {
                   {(selectedGeoFilters.includes('other') || selectedGeoFilters.includes('all')) && <span>✓</span>}
                 </GeographyFilterPill>
               </GeographyFilterContainer>
-              <GeographyFilterPill onClick={() => setSelectedGeoFilters([])}>
-                <>Clear all geographies</>
-                <span>X</span>
+              <GeographyFilterPill
+                onClick={() => selectedGeoFilters.length === 0 ? setSelectedGeoFilters(['all']) : setSelectedGeoFilters([])}
+                className={selectedGeoFilters.length === 0 ? 'selected' : ''}
+              >
+                <>
+                  {selectedGeoFilters.length === 0 ? "Select all geographies" : "Clear all geographies"}
+                </>
+                <span>{selectedGeoFilters.length !== 0 ? "X" : "✓"}</span>
               </GeographyFilterPill>
             </GeographyBarContainer>
           </SearchInputContainer>

--- a/src/pages/BrowserPage.jsx
+++ b/src/pages/BrowserPage.jsx
@@ -270,6 +270,38 @@ const DatasetGrid = styled.div`
   }
 `;
 
+const DatasetContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const DatasetTabs = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+const GeographyTab = styled.div`
+  position: relative;
+  top: 5px;
+  cursor: pointer;
+  padding: 6px 12px 10px 12px;
+  background: #f9f9f9;
+  border: 1px solid #e0e0e0;
+  border-bottom: none;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+
+  &:hover {
+    background: #f1f1f1;
+    border: 1px solid #dadada;
+    border-bottom: none;
+  }
+
+  &.selected {
+    z-index: 99;
+    background: #ffffff;
+  }
+`;
+
 const DatasetBox = styled.div`
   background: white;
   border: 1px solid #e0e0e0;
@@ -326,20 +358,6 @@ const InfoValue = styled.span`
   color: #555;
 `;
 
-const InfoGeographyValue = styled.div`
-  color: #4ea56c;
-  border: 1px solid #4ea56c;
-  border-radius: 12px;
-  padding: 4px 8px 6px;
-  line-height: 14px;
-  cursor: pointer;
-
-  &:hover {
-    color: #367a4e;
-    border: 1px solid #367a4e;
-  }
-`;
-
 const DatasetActions = styled.div`
   display: flex;
   flex-direction: column;
@@ -365,38 +383,6 @@ const ViewMetadataButton = styled.button`
   
   &:hover {
     opacity: 0.9;
-  }
-`;
-
-const ViewMetadataDropdownContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const ViewMetadataDropdownOptionsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  position: absolute;
-  top: 2.5rem;
-  z-index: 999;
-  border-radius: 5px;
-`;
-
-const ViewMetadataDropdownOption = styled.button`
-  width: 10rem;
-  background-color: #64c08d;
-  color: white;
-  border: none;
-  padding: 0.3rem 1rem;
-  font-size: 0.8rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background-color: #7bc69d;
   }
 `;
 
@@ -536,6 +522,7 @@ const BrowserPage = () => {
     return geoFilterParams ? geoFilterParams.split(",").filter(Boolean) : ['all'];
   });
 
+  const [selectedGeographyTabs, setSelectedGeographyTabs] = useState({});
   const [categoryOptionTree, setCategoryOptionTree] = useState({});
   const [sortBy, setSortBy] = useState('Relevance');
   const [selectedDataset, setSelectedDataset] = useState(null);
@@ -678,8 +665,8 @@ const BrowserPage = () => {
       }
     });
 
-    // set the matched search terms to be highlighted
-    const highlights = highlightDatasets({ searchQuery, datasets: compressedDatasets });
+    // set the matched search terms to be highlighted (use filtered list not compressed datasets)
+    const highlights = highlightDatasets({ searchQuery, datasets: filtered });
 
     setHighlightMatches(highlights);
     setDisplayDatasets(compressedDatasets);
@@ -923,19 +910,42 @@ const BrowserPage = () => {
     setSelectedDataset(null);
   };
 
+  const onGeoTabClicked = (compressedDatasetId, geography) => {
+    const newSelectedGeoTabs = {...selectedGeographyTabs};
+
+    newSelectedGeoTabs[compressedDatasetId] = geography;
+    setSelectedGeographyTabs(newSelectedGeoTabs);
+  }
+
+  const isTabSelected = (selectedGeographyTabs, compressedDataset, geography) => {
+    const compressedId = compressedDataset.id || compressedDataset.seq_id;
+    if (!selectedGeographyTabs[compressedId]) {
+      return compressedDataset.geoIdPairs.filter(pair => !!pair.geography)[0].geography === geography;
+    } else {
+      return selectedGeographyTabs[compressedId] === geography;
+    }
+  }
+
+  const getSelectedDataset = (compressedDataset) => {
+    const compressedId = compressedDataset.id || compressedDataset.seq_id;
+    if (compressedDataset.datasets.length === 1) {
+      return compressedDataset.datasets[0];
+    }
+    
+    let selectedDatasetId;
+    if (!selectedGeographyTabs[compressedId]) {
+      selectedDatasetId = compressedDataset.geoIdPairs.filter(pair => !!pair.geography)[0].id;
+    } else {
+      const selectedGeography = selectedGeographyTabs[compressedId];
+      selectedDatasetId = compressedDataset.geoIdPairs.find(geoIdPair => geoIdPair.geography === selectedGeography).id;
+    }
+
+    return compressedDataset.datasets.find(d => d.seq_id === selectedDatasetId);
+  }
+
   const toDataset = (datasetId) => {
     // open in new tab to preserve user's search & filters from the datasets landing page
     window.open(`/browser/datasets/${datasetId}`, '_blank', 'noreferrer');
-  };
-
-  const handleDatasetClick = (compressedDataset) => {
-    // handle case of one dataset
-    if (compressedDataset.datasets.length === 1) {
-      toDataset(compressedDataset.datasets[0].seq_id);
-    } else {
-      // otherwise use the first one in the order the geos were sorted in
-      toDataset(compressedDataset.geoIdPairs[0].id);
-    }
   };
 
   return (
@@ -1114,87 +1124,59 @@ const BrowserPage = () => {
           <DatasetGrid ref={datasetGridRef}>
             {sortedDatasets.map((compressedDataset) => {
               const compressedDatasetId = compressedDataset.seq_id || compressedDataset.id;
+              const selectedDatasetFromTab = getSelectedDataset(compressedDataset);
               return (
-                <DatasetBox 
-                  key={compressedDatasetId}
-                  onClick={() => handleDatasetClick(compressedDataset)}
-                >
-                  <DatasetHeaderContainer>
-                    <DatasetHeader>
-                      {renderHighlightedText(compressedDataset.menu3, compressedDatasetId, 'menu3')}
-                    </DatasetHeader>
-                    {compressedDataset.datasets.length === 1 && 
+                <DatasetContainer>
+                  <DatasetTabs>
+                    {compressedDataset.geoIdPairs.filter(pair => !!pair.geography).map(geoIdPair =>
+                      <GeographyTab
+                        key={`${compressedDataset.id}_${geoIdPair.geography}`}
+                        className={isTabSelected(selectedGeographyTabs, compressedDataset, geoIdPair.geography) ? "selected" : ""}
+                        onClick={() => onGeoTabClicked(compressedDatasetId, geoIdPair.geography)}
+                      >
+                        {geoIdPair.geography}
+                      </GeographyTab>
+                    )}
+                  </DatasetTabs>
+                  <DatasetBox
+                    key={selectedDatasetFromTab.seq_id}
+                    onClick={() => toDataset(selectedDatasetFromTab.seq_id)}
+                  >
+                    <DatasetHeaderContainer>
+                      <DatasetHeader>
+                        {renderHighlightedText(selectedDatasetFromTab.menu3, selectedDatasetFromTab.seq_id, 'menu3')}
+                      </DatasetHeader>
                       <ViewMetadataButton
                         onClick={(e) => {
                           e.stopPropagation();
-                          handleViewMetadata(compressedDataset.datasets[0]);
+                          handleViewMetadata(selectedDatasetFromTab);
                         }}
                       >
                         View Metadata
                       </ViewMetadataButton>
-                    }
-                    {compressedDataset.datasets.length !== 1 && 
-                    <ViewMetadataDropdownContainer>
-                      <ViewMetadataButton
-                        onClick={e => {
-                          e.stopPropagation();
-                          viewingMetadataDropdownId === compressedDatasetId ? setViewingMetadataDropdownId(null) : setViewingMetadataDropdownId(compressedDatasetId);
-                        }}
-                      >
-                        View Metadata <span style={{ float: 'right' }}>▼</span>
-                      </ViewMetadataButton>
-                      <ViewMetadataDropdownOptionsContainer>
-                        {viewingMetadataDropdownId === compressedDatasetId && compressedDataset.geoIdPairs.map(geoIdPair => 
-                          <ViewMetadataDropdownOption 
-                            key={geoIdPair.id}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setViewingMetadataDropdownId(null);
-                              handleViewMetadata(compressedDataset.datasets.filter(d => d.seq_id === geoIdPair.id)[0]);
-                            }}
-                          >
-                            {geoIdPair.geography}
-                          </ViewMetadataDropdownOption>
-                        )}
-                      </ViewMetadataDropdownOptionsContainer>
-                    </ViewMetadataDropdownContainer>
-                    }
-                  </DatasetHeaderContainer>
-                  <DatasetBody>
-                    <DatasetInfo>
-                      <InfoRow>
-                        <InfoLabel>Table:</InfoLabel>
-                        <InfoValue>
-                          {renderHighlightedText(compressedDataset.table_name, compressedDatasetId, 'table_name')}
-                        </InfoValue>
-                      </InfoRow>
-                      <InfoRow>
-                        <InfoLabel>Source:</InfoLabel>
-                        <InfoValue>{compressedDataset.source}</InfoValue>
-                      </InfoRow>
-                      {compressedDataset.geoIdPairs.filter(pair => !!pair.geography).length > 0 && <InfoRow>
-                        <InfoLabel>Geographies:</InfoLabel>
-                        {compressedDataset.geoIdPairs.map(geoIdPair => 
-                          <InfoGeographyValue
-                            key={geoIdPair.id}
-                            onClick={e => {
-                              e.stopPropagation();
-                              toDataset(geoIdPair.id);
-                            }}
-                          >
-                            {geoIdPair.geography}
-                          </InfoGeographyValue>
-                        )}
-                      </InfoRow>}
-                    </DatasetInfo>
-                    <DatasetActions>
-                      <LastUpdated>
-                        <LastUpdatedLabel>Last updated:</LastUpdatedLabel>
-                        {formatUpdated(compressedDataset.updated)}
-                      </LastUpdated>
-                    </DatasetActions>
-                  </DatasetBody>
-                </DatasetBox>
+                    </DatasetHeaderContainer>
+                    <DatasetBody>
+                      <DatasetInfo>
+                        <InfoRow>
+                          <InfoLabel>Table:</InfoLabel>
+                          <InfoValue>
+                            {renderHighlightedText(selectedDatasetFromTab.table_name, selectedDatasetFromTab.seq_id, 'table_name')}
+                          </InfoValue>
+                        </InfoRow>
+                        <InfoRow>
+                          <InfoLabel>Source:</InfoLabel>
+                          <InfoValue>{selectedDatasetFromTab.source}</InfoValue>
+                        </InfoRow>
+                      </DatasetInfo>
+                      <DatasetActions>
+                        <LastUpdated>
+                          <LastUpdatedLabel>Last updated:</LastUpdatedLabel>
+                          {formatUpdated(selectedDatasetFromTab.updated)}
+                        </LastUpdated>
+                      </DatasetActions>
+                    </DatasetBody>
+                  </DatasetBox>
+                </DatasetContainer>
               );
             })}
           </DatasetGrid>


### PR DESCRIPTION
Different geographies for the same table are now listed as tabs at the top of a dataset card. This allows for the source and updated fields to directly reflect the dataset being viewed. Also removes the behavior of selecting the metadata to view from a dropdown. 

Also updates the "clear all geographies" button attached that's used to manage the geography filter on the dataset browser page. The button now switches to "select all geographies" if none are selected. 

<img width="1415" height="684" alt="Screenshot 2026-04-29 at 3 26 15 PM" src="https://github.com/user-attachments/assets/277a9290-8d5f-4b77-8a47-a1dfc5c458be" />
