### PR TITLE
remove MOE from column selection dropdown/add search bar

### DIFF
--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -285,7 +285,54 @@ const GeographyFilter = ({ availableGeographies = [], selectedGeographies = [], 
 
 const ColumnSelectorDropdown = ({ columnKeys, updateSelectedColumns, selectedColumns }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [columnSearchQuery, setColumnSearchQuery] = useState("");
   const dropdownRef = useRef(null);
+
+  const getMarginColumnsByBase = (keys = []) => {
+    const byName = new Set((keys || []).map((c) => String(c?.name || "")));
+    const pairs = {};
+    const byAlias = {};
+    (keys || []).forEach((col) => {
+      const alias = String(col?.alias || "").trim().toLowerCase();
+      if (alias) byAlias[alias] = String(col?.name || "");
+    });
+
+    const getBaseCandidates = (name) => {
+      const candidates = [];
+      if (name.endsWith("_mp")) {
+        candidates.push(name.slice(0, -3) + "_p");
+        candidates.push(name.slice(0, -3));
+      }
+      if (name.endsWith("_me")) candidates.push(name.slice(0, -3));
+      if (name.endsWith("_moe")) candidates.push(name.slice(0, -4));
+      if (name.endsWith("_m")) candidates.push(name.slice(0, -2));
+      return candidates.filter(Boolean);
+    };
+
+    const isMarginColumn = (col) => {
+      const name = String(col?.name || "");
+      const alias = String(col?.alias || "").toLowerCase();
+      const details = String(col?.details || "").toLowerCase();
+      const hintFromMetadata = alias.includes("margin of error") || details.includes("margin of error");
+      const suffixHint = /(_mp|_me|_moe|_m)$/i.test(name);
+      if (!hintFromMetadata && !suffixHint) return { isMargin: false, base: null };
+      if (alias.includes("margin of error")) {
+        const estimateAlias = alias.replace("margin of error", "estimate").replace(/\s+/g, " ").trim();
+        if (byAlias[estimateAlias]) return { isMargin: true, base: byAlias[estimateAlias] };
+      }
+      const base = getBaseCandidates(name).find((candidate) => byName.has(candidate));
+      return { isMargin: true, base: base || null };
+    };
+
+    (keys || []).forEach((col) => {
+      const result = isMarginColumn(col);
+      if (!result?.isMargin || !result.base) return;
+      if (!pairs[result.base]) pairs[result.base] = [];
+      pairs[result.base].push(col.name);
+    });
+
+    return pairs;
+  };
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -303,18 +350,40 @@ const ColumnSelectorDropdown = ({ columnKeys, updateSelectedColumns, selectedCol
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      setColumnSearchQuery("");
+    }
+  }, [isOpen]);
+
   if (!columnKeys || columnKeys.length === 0) {
     return null;
   }
 
-  // Sort columns alphabetically by alias (or name if no alias)
-  const sortedColumnKeys = [...columnKeys].sort((a, b) => {
+  const marginColumnsByBase = getMarginColumnsByBase(columnKeys);
+  const isMarginColumn = (col) => {
+    const name = String(col?.name || "");
+    const alias = String(col?.alias || "").toLowerCase();
+    const details = String(col?.details || "").toLowerCase();
+    return alias.includes("margin of error") || details.includes("margin of error") || /(_mp|_me|_moe|_m)$/i.test(name);
+  };
+  const visibleColumnKeys = columnKeys.filter((col) => !isMarginColumn(col));
+
+  // Sort selectable (non-MOE) columns alphabetically by alias (or name if no alias)
+  const sortedColumnKeys = [...visibleColumnKeys].sort((a, b) => {
     const aName = (a.alias || a.name).toLowerCase();
     const bName = (b.alias || b.name).toLowerCase();
     return aName.localeCompare(bName);
   });
+  const filteredColumnKeys = sortedColumnKeys.filter((column) => {
+    const query = columnSearchQuery.trim().toLowerCase();
+    if (!query) return true;
+    const label = String(column.alias || column.name || "").toLowerCase();
+    const name = String(column.name || "").toLowerCase();
+    return label.includes(query) || name.includes(query);
+  });
 
-  const selectedCount = selectedColumns.length;
+  const selectedCount = sortedColumnKeys.filter((col) => selectedColumns.includes(col.name)).length;
   const totalCount = sortedColumnKeys.length;
   const displayText = selectedCount === totalCount 
     ? `All Columns (${totalCount})` 
@@ -360,21 +429,42 @@ const ColumnSelectorDropdown = ({ columnKeys, updateSelectedColumns, selectedCol
               {selectedCount === totalCount ? 'Deselect All' : 'Select All'}
             </button>
           </div>
+          <div style={{ padding: "8px 0 10px 0" }}>
+            <input
+              type="text"
+              placeholder="Search columns..."
+              value={columnSearchQuery}
+              onChange={(e) => setColumnSearchQuery(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+              style={{
+                width: "100%",
+                padding: "8px 10px",
+                border: "1px solid #ccc",
+                borderRadius: 4,
+                fontSize: "12px",
+              }}
+            />
+          </div>
           <div className="column-checkboxes">
-            {sortedColumnKeys.map((column) => (
-              <label key={column.name} className="column-checkbox-label">
-              <input
-                type="checkbox"
-                checked={selectedColumns.includes(column.name)}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  updateSelectedColumns(column.name);
-                }}
-                className="column-checkbox"
-              />
-                <span>{column.alias || column.name}</span>
-              </label>
-            ))}
+            {filteredColumnKeys.length === 0 ? (
+              <div style={{ padding: "8px 0", fontSize: "12px", color: "#777" }}>No matches</div>
+            ) : (
+              filteredColumnKeys.map((column) => (
+                <label key={column.name} className="column-checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={selectedColumns.includes(column.name)}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      updateSelectedColumns(column.name);
+                    }}
+                    className="column-checkbox"
+                  />
+                  <span>{column.alias || column.name}</span>
+                </label>
+              ))
+            )}
           </div>
         </div>
       )}

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -23,6 +23,7 @@ class DataViewerClass extends React.Component {
       loading: true,
       rowsPerPage: 25,
       selectedColumns: [], // Will be initialized with all columns
+      marginColumnsByBase: {},
       availableGeographies: [],
       selectedGeographies: [],
       geographyColumn: null,
@@ -35,6 +36,102 @@ class DataViewerClass extends React.Component {
     this.loadDatasetData = this.loadDatasetData.bind(this);
     this.updateSelectedGeographies = this.updateSelectedGeographies.bind(this);
     this.hasLoaded = false; // Flag to prevent duplicate API calls in StrictMode
+  }
+
+  getMarginColumnsByBase(columnKeys = []) {
+    const byName = new Set((columnKeys || []).map((c) => String(c?.name || "")));
+    const pairs = {};
+    const byAlias = {};
+    (columnKeys || []).forEach((col) => {
+      const alias = String(col?.alias || "").trim().toLowerCase();
+      if (alias) byAlias[alias] = String(col?.name || "");
+    });
+
+    const normalizeAliasMetric = (text) =>
+      String(text || "")
+        .toLowerCase()
+        .replace(/\s*;\s*(estimate|margin of error)\s*$/i, "")
+        .replace(/\s*,\s*(estimate|margin of error)\s*$/i, "")
+        .trim();
+
+    const getBaseCandidates = (name) => {
+      const candidates = [];
+      if (name.endsWith("_mp")) {
+        candidates.push(name.slice(0, -3) + "_p");
+        candidates.push(name.slice(0, -3));
+      }
+      if (name.endsWith("_me")) {
+        candidates.push(name.slice(0, -3));
+      }
+      if (name.endsWith("_moe")) {
+        candidates.push(name.slice(0, -4));
+      }
+      if (name.endsWith("_m")) {
+        candidates.push(name.slice(0, -2));
+      }
+      return candidates.filter(Boolean);
+    };
+
+    const isMarginColumn = (col) => {
+      const name = String(col?.name || "");
+      const alias = String(col?.alias || "").toLowerCase();
+      const details = String(col?.details || "").toLowerCase();
+      const hintFromMetadata = alias.includes("margin of error") || details.includes("margin of error");
+      const suffixHint = /(_mp|_me|_moe|_m)$/i.test(name);
+      if (!hintFromMetadata && !suffixHint) return { isMargin: false, base: null };
+
+      // Prefer alias-based pairing for ACS-style labels:
+      // "X; margin of error" -> "X; estimate"
+      if (alias.includes("margin of error")) {
+        const estimateAlias = alias.replace("margin of error", "estimate").replace(/\s+/g, " ").trim();
+        if (byAlias[estimateAlias]) {
+          return { isMargin: true, base: byAlias[estimateAlias] };
+        }
+        const normalized = normalizeAliasMetric(alias);
+        const matchedBase = (columnKeys || []).find((candidate) => {
+          const a = String(candidate?.alias || "").toLowerCase();
+          const isEstimate = /\bestimate\b/i.test(a) || (!/\bmargin of error\b/i.test(a) && !!a);
+          return isEstimate && normalizeAliasMetric(a) === normalized;
+        });
+        if (matchedBase?.name) {
+          return { isMargin: true, base: matchedBase.name };
+        }
+      }
+
+      const base = getBaseCandidates(name).find((candidate) => byName.has(candidate));
+      return { isMargin: true, base: base || null };
+    };
+
+    (columnKeys || []).forEach((col) => {
+      const name = String(col?.name || "");
+      const result = isMarginColumn(col);
+      if (!result?.isMargin || !result.base || !name) return;
+      if (!pairs[result.base]) pairs[result.base] = [];
+      pairs[result.base].push(name);
+    });
+
+    return pairs;
+  }
+
+  getVisibleColumnKeys(columnKeys = []) {
+    const isMarginColumn = (col) => {
+      const name = String(col?.name || "");
+      const alias = String(col?.alias || "").toLowerCase();
+      const details = String(col?.details || "").toLowerCase();
+      return alias.includes("margin of error") || details.includes("margin of error") || /(_mp|_me|_moe|_m)$/i.test(name);
+    };
+    return (columnKeys || []).filter((col) => !isMarginColumn(col));
+  }
+
+  expandSelectedWithMargins(selectedBaseColumns = [], marginColumnsByBase = {}) {
+    const next = [...selectedBaseColumns];
+    selectedBaseColumns.forEach((base) => {
+      const margins = marginColumnsByBase?.[base] || [];
+      margins.forEach((m) => {
+        if (!next.includes(m)) next.push(m);
+      });
+    });
+    return next;
   }
 
   componentDidMount() {
@@ -125,13 +222,17 @@ class DataViewerClass extends React.Component {
           // Process the distinct year data
           const distinctYears = yearResults.map((year) => Object.values(year)[0]).sort().reverse();
 
+          const visibleColumnKeys = this.getVisibleColumnKeys(columnKeys);
+          const marginColumnsByBase = this.getMarginColumnsByBase(columnKeys);
+          const selectedBaseColumns = visibleColumnKeys.map((col) => col.name);
           this.setState({
             availableYears: distinctYears,
             rows: tableResults,
             universe: universeData ? universeData.details : "",
             description: descriptionData ? descriptionData.details : "",
             columnKeys: columnKeys,
-            selectedColumns: columnKeys.map((col) => col.name), // Initialize with all columns
+            selectedColumns: this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase),
+            marginColumnsByBase,
             metadata,
             selectedYears: distinctYears.length ? [distinctYears[0]] : [],
             table: dataset.table_name,
@@ -174,12 +275,16 @@ class DataViewerClass extends React.Component {
             // Process the distinct year data
             const distinctYears = yearResults.map((year) => Object.values(year)[0]).sort().reverse();
 
+            const visibleColumnKeys = this.getVisibleColumnKeys(sortedMetadata);
+            const marginColumnsByBase = this.getMarginColumnsByBase(sortedMetadata);
+            const selectedBaseColumns = visibleColumnKeys.map((col) => col.name);
             this.setState({
               availableYears: distinctYears,
               rows: tableResults,
               description: metadata.documentation.metadata.dataIdInfo.idPurp || "",
               columnKeys: sortedMetadata,
-              selectedColumns: sortedMetadata.map((col) => col.name), // Initialize with all columns
+              selectedColumns: this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase),
+              marginColumnsByBase,
               metadata,
               selectedYears: distinctYears.length ? [distinctYears[0]] : [],
               table: dataset.table_name,
@@ -228,15 +333,16 @@ class DataViewerClass extends React.Component {
 
   updateSelectedColumns(columnName) {
     this.setState((prevState) => {
+      const marginColumns = prevState.marginColumnsByBase?.[columnName] || [];
       if (prevState.selectedColumns.includes(columnName)) {
-        const index = prevState.selectedColumns.indexOf(columnName);
-        const front = prevState.selectedColumns.slice(0, index);
-        const back = prevState.selectedColumns.slice(index + 1);
-        const newArray = front.concat(back);
-        return { selectedColumns: newArray };
+        const next = prevState.selectedColumns.filter((col) => col !== columnName && !marginColumns.includes(col));
+        return { selectedColumns: next };
       }
-      prevState.selectedColumns.push(columnName);
-      return { selectedColumns: prevState.selectedColumns };
+      const next = [...prevState.selectedColumns, columnName];
+      marginColumns.forEach((col) => {
+        if (!next.includes(col)) next.push(col);
+      });
+      return { selectedColumns: next };
     });
   }
 


### PR DESCRIPTION
-Add column-name search to the column selector (matching the geography filter UX), hide all margin-of-error columns from that selector, and when a user selects a base column, automatically include both the selected column and its corresponding margin-of-error column in the table.