### PR TITLE
make share/embed table to include filters

### DIFF
--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -150,6 +150,25 @@
       display: flex;
       flex-direction: column;
 
+      &.column-dropdown-menu--geography {
+        min-width: 440px;
+        max-width: min(640px, calc(100vw - 28px));
+
+        .column-dropdown-header {
+          flex-wrap: nowrap;
+
+          > span {
+            min-width: 0;
+            flex: 1 1 auto;
+          }
+
+          .column-dropdown-bulk-actions {
+            flex-wrap: nowrap;
+            flex-shrink: 0;
+          }
+        }
+      }
+
       .column-dropdown-header {
         display: flex;
         justify-content: space-between;
@@ -165,6 +184,14 @@
           font-size: $font_size-xsmall;
         }
 
+        .column-dropdown-bulk-actions {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+          align-items: center;
+          justify-content: flex-end;
+        }
+
         .select-all-button {
           padding: 4px 8px;
           border: 1px solid $color_brand-secondary;
@@ -174,11 +201,26 @@
           cursor: pointer;
           font-size: 11px;
           font-weight: 500;
-          transition: background-color .14s, color .14s;
+          transition: background-color .14s, color .14s, opacity .14s;
 
-          &:hover {
+          &:hover:not(:disabled) {
             background: $color_brand-secondary;
             color: white;
+          }
+
+          &:disabled {
+            opacity: .45;
+            cursor: not-allowed;
+          }
+        }
+
+        .column-dropdown-clear-button {
+          border-color: rgba($color_font-medium, 0.55);
+          color: $color_font-medium;
+
+          &:hover:not(:disabled) {
+            background: rgba($color_font-medium, 0.12);
+            color: $color_font-dark;
           }
         }
       }
@@ -688,6 +730,12 @@
     border-radius: 8px;
     background: #fff;
     overflow: hidden;
+
+    &.is-disabled {
+      opacity: 0.55;
+      background: #f3f3f3;
+      cursor: not-allowed;
+    }
   }
 
   .download-endpoint-field-body {
@@ -697,6 +745,10 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+
+    .download-endpoint-field.is-disabled & {
+      cursor: not-allowed;
+    }
   }
 
   .download-endpoint-field-label {
@@ -714,6 +766,10 @@
     max-height: 120px;
     overflow-y: auto;
     padding-right: 2px;
+
+    .download-endpoint-field.is-disabled & {
+      cursor: not-allowed;
+    }
   }
 
   .download-endpoint-field-copy {
@@ -739,6 +795,17 @@
     &:focus {
       outline: none;
       box-shadow: inset 0 0 0 2px rgba($color_brand-secondary, 0.35);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      color: rgba($color_font-medium, 0.9);
+      background: #efefef;
+    }
+
+    &:disabled:hover {
+      background: #efefef;
+      color: rgba($color_font-medium, 0.9);
     }
   }
 
@@ -785,11 +852,13 @@
     }
   }
 
-  // Share & Embed modal (tab style inspired by data portal “copy link” UI)
+  // Share & Embed modal 
   $embed-tab-inactive: #6b7280;
   $embed-border: #d1d5db;
 
   .embed-table-modal {
+    width: min(720px, calc(100vw - 28px));
+
     .download-modal-body {
       padding-top: 0;
     }
@@ -870,6 +939,49 @@
       font-weight: 400;
       color: $color_font-medium;
       line-height: 1.45;
+    }
+
+    .embed-table-modal-url-warning {
+      margin: -4px 0 12px;
+      padding: 10px 12px;
+      font-family: $font_family-primary;
+      font-size: $font_size-xsmall;
+      line-height: 1.45;
+      color: #664d03;
+      background: #fff3cd;
+      border: 1px solid #ffecb5;
+      border-radius: $elem_button-radius;
+    }
+
+    .embed-table-modal-url-ready {
+      margin: 0 0 10px;
+      padding: 8px 10px;
+      font-family: $font_family-primary;
+      font-size: $font_size-xsmall;
+      line-height: 1.45;
+      color: #0f5132;
+      background: #d1e7dd;
+      border: 1px solid #badbcc;
+      border-radius: $elem_button-radius;
+    }
+
+    .embed-table-modal-overlimit-editor {
+      margin: -2px 0 12px;
+      padding: 10px 12px;
+      border: 1px solid rgba($color_font-medium, 0.25);
+      border-radius: $elem_button-radius;
+      background: rgba($color_bg-medium, 0.2);
+    }
+
+    .embed-table-modal-overlimit-title {
+      margin: 0 0 8px;
+      font-size: $font_size-xsmall;
+      font-weight: 600;
+      color: $color_font-dark;
+    }
+
+    .embed-table-modal-dataset-filters .year-filter {
+      margin-bottom: 10px;
     }
 
     .embed-table-modal-kicker {

--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { useLocation } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -7,6 +7,7 @@ import { faMessage } from "@fortawesome/free-regular-svg-icons";
 import { formatUpdated } from "../../utils/formatUpdated";
 import ExportDataModal from "./ExportDataModal";
 import EmbedTableModal from "./EmbedTableModal";
+import { buildDatasetViewShareSearchParams, DATASET_VIEW_SHARE_MAX_URL_LENGTH } from "../../utils/datasetViewShareQuery";
 
 const setSelectYears = (availableYears, updateSelectedYears, selectedYears) => {
   if (availableYears.length > 0) {
@@ -83,33 +84,41 @@ const GeographyFilter = ({ availableGeographies = [], selectedGeographies = [], 
         <span className="dropdown-arrow">{isOpen ? "▲" : "▼"}</span>
       </button>
       {isOpen && (
-        <div className="column-dropdown-menu">
+        <div className="column-dropdown-menu column-dropdown-menu--geography">
           <div className="column-dropdown-header">
             <span>{displayText}</span>
-            <button
-              type="button"
-              className="select-all-button"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (selectedCount === totalCount) {
-                  // Deselect all
-                  availableGeographies.forEach((geo) => {
-                    if (selectedGeographies.includes(geo)) {
-                      updateSelectedGeographies(geo);
-                    }
-                  });
-                } else {
-                  // Select all
+            <div className="column-dropdown-bulk-actions" role="group" aria-label="Geography bulk selection">
+              <button
+                type="button"
+                className="select-all-button"
+                disabled={selectedCount === totalCount}
+                onClick={(e) => {
+                  e.stopPropagation();
                   availableGeographies.forEach((geo) => {
                     if (!selectedGeographies.includes(geo)) {
                       updateSelectedGeographies(geo);
                     }
                   });
-                }
-              }}
-            >
-              {selectedCount === totalCount ? "Deselect All" : "Select All"}
-            </button>
+                }}
+              >
+                Select All
+              </button>
+              <button
+                type="button"
+                className="select-all-button column-dropdown-clear-button"
+                disabled={selectedCount === 0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  availableGeographies.forEach((geo) => {
+                    if (selectedGeographies.includes(geo)) {
+                      updateSelectedGeographies(geo);
+                    }
+                  });
+                }}
+              >
+                Clear All
+              </button>
+            </div>
           </div>
 
           {selectedCount > 0 && (
@@ -475,29 +484,38 @@ const ColumnSelectorDropdown = ({ columnKeys, updateSelectedColumns, selectedCol
         <div className="column-dropdown-menu">
           <div className="column-dropdown-header">
             <span>Select Columns:</span>
-            <button
-              type="button"
-              className="select-all-button"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (visibleSelectedCount === visibleSelectableCount) {
-                  sortedColumnKeys.forEach((col) => {
-                    if (selectedColumns.includes(col.name)) {
-                      updateSelectedColumns(col.name);
-                    }
-                  });
-                } else {
-                  // Select all columns that aren't currently selected
+            <div className="column-dropdown-bulk-actions" role="group" aria-label="Column bulk selection">
+              <button
+                type="button"
+                className="select-all-button"
+                disabled={visibleSelectedCount >= visibleSelectableCount || visibleSelectableCount === 0}
+                onClick={(e) => {
+                  e.stopPropagation();
                   sortedColumnKeys.forEach((col) => {
                     if (!selectedColumns.includes(col.name)) {
                       updateSelectedColumns(col.name);
                     }
                   });
-                }
-              }}
-            >
-              {visibleSelectedCount === visibleSelectableCount ? 'Deselect All' : 'Select All'}
-            </button>
+                }}
+              >
+                Select All
+              </button>
+              <button
+                type="button"
+                className="select-all-button column-dropdown-clear-button"
+                disabled={visibleSelectedCount === 0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  sortedColumnKeys.forEach((col) => {
+                    if (selectedColumns.includes(col.name)) {
+                      updateSelectedColumns(col.name);
+                    }
+                  });
+                }}
+              >
+                Clear All
+              </button>
+            </div>
           </div>
           <div
             className="column-dropdown-moe-help"
@@ -612,6 +630,70 @@ function DatasetHeader({
   const [embedModalOpen, setEmbedModalOpen] = useState(false);
   const [actionsOpen, setActionsOpen] = useState(false);
   const actionsDropdownRef = useRef(null);
+
+  const { sharePageUrl, embedPageUrl, shareUrlTooLong } = useMemo(() => {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const basePath = `${origin}/browser/datasets/${datasetId}`;
+    const shareArgs = {
+      columnKeys,
+      selectedColumns,
+      availableGeographies,
+      selectedGeographies,
+      availableYears,
+      selectedYears,
+      queryYearColumn,
+    };
+    const shareParams = buildDatasetViewShareSearchParams({ embed: false, ...shareArgs });
+    const embedParams = buildDatasetViewShareSearchParams({ embed: true, ...shareArgs });
+    const qsShare = shareParams.toString();
+    const qsEmbed = embedParams.toString();
+    const sharePageUrl = qsShare ? `${basePath}?${qsShare}` : basePath;
+    const embedPageUrl = qsEmbed ? `${basePath}?${qsEmbed}` : `${basePath}?embed=1`;
+    const shareUrlTooLong =
+      sharePageUrl.length > DATASET_VIEW_SHARE_MAX_URL_LENGTH ||
+      embedPageUrl.length > DATASET_VIEW_SHARE_MAX_URL_LENGTH;
+    return { sharePageUrl, embedPageUrl, shareUrlTooLong };
+  }, [
+    datasetId,
+    columnKeys,
+    selectedColumns,
+    selectedGeographies,
+    availableGeographies,
+    selectedYears,
+    availableYears,
+    queryYearColumn,
+  ]);
+
+  const embedModalAdjustFilters = useMemo(
+    () => (
+      <>
+        {setSelectYears(availableYears, updateSelectedYears, selectedYears)}
+        <div style={{ marginTop: "12px", display: "flex", gap: "12px", flexWrap: "wrap" }}>
+          <ColumnSelectorDropdown
+            columnKeys={columnKeys}
+            updateSelectedColumns={updateSelectedColumns}
+            selectedColumns={selectedColumns}
+          />
+          <GeographyFilter
+            availableGeographies={availableGeographies}
+            selectedGeographies={selectedGeographies}
+            updateSelectedGeographies={updateSelectedGeographies}
+          />
+        </div>
+      </>
+    ),
+    [
+      availableYears,
+      updateSelectedYears,
+      selectedYears,
+      columnKeys,
+      updateSelectedColumns,
+      selectedColumns,
+      availableGeographies,
+      selectedGeographies,
+      updateSelectedGeographies,
+    ],
+  );
 
   useEffect(() => {
     if (!actionsOpen) {
@@ -777,6 +859,10 @@ function DatasetHeader({
         onClose={() => setEmbedModalOpen(false)}
         datasetId={datasetId}
         title={title}
+        shareUrl={sharePageUrl}
+        embedUrl={embedPageUrl}
+        urlTooLong={shareUrlTooLong}
+        adjustUrlFiltersSlot={embedModalAdjustFilters}
       />
     </div>
   );
@@ -805,7 +891,7 @@ DatasetHeader.propTypes = {
   universe: PropTypes.string,
   updatedAt: PropTypes.string,
   rowsPerPage: PropTypes.number,
-  updateRowsPerPage: PropTypes.func
+  updateRowsPerPage: PropTypes.func,
 };
 
 export default DatasetHeader;

--- a/src/components/partials/EmbedTableModal.jsx
+++ b/src/components/partials/EmbedTableModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
@@ -30,7 +30,16 @@ const getPresetForDimensions = (width, height) => {
   return "custom";
 };
 
-const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
+const EmbedTableModal = ({
+  isOpen,
+  onClose,
+  datasetId,
+  title,
+  shareUrl: shareUrlProp,
+  embedUrl: embedUrlProp,
+  urlTooLong = false,
+  adjustUrlFiltersSlot = null,
+}) => {
   const [panel, setPanel] = useState("share");
   /** Shown in inputs while typing; only digits (empty allowed briefly). */
   const [widthInput, setWidthInput] = useState(String(IFRAME_WIDTH_DEFAULT));
@@ -40,6 +49,8 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
   const [heightCommitted, setHeightCommitted] = useState(IFRAME_HEIGHT_DEFAULT);
   const [sizePreset, setSizePreset] = useState("large");
   const [copyStatus, setCopyStatus] = useState("");
+  /** Once the share URL is too long while this dialog is open, keep filter controls visible after it fits again. */
+  const [keepAdjustFiltersVisible, setKeepAdjustFiltersVisible] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -53,19 +64,32 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
     }
   }, [isOpen]);
 
-  const sourceUrl = useMemo(() => {
+  useEffect(() => {
+    if (!isOpen) {
+      setKeepAdjustFiltersVisible(false);
+      return;
+    }
+    if (urlTooLong) {
+      setKeepAdjustFiltersVisible(true);
+    }
+  }, [isOpen, urlTooLong]);
+
+  const fallbackSourceUrl = useMemo(() => {
     if (typeof window === "undefined") {
       return `/browser/datasets/${datasetId}`;
     }
     return `${window.location.origin}/browser/datasets/${datasetId}`;
   }, [datasetId]);
 
-  const embedUrl = useMemo(() => {
+  const fallbackEmbedUrl = useMemo(() => {
     if (typeof window === "undefined") {
       return `/browser/datasets/${datasetId}?embed=1`;
     }
     return `${window.location.origin}/browser/datasets/${datasetId}?embed=1`;
   }, [datasetId]);
+
+  const sourceUrl = shareUrlProp ?? fallbackSourceUrl;
+  const embedUrl = embedUrlProp ?? fallbackEmbedUrl;
 
   const resolveWidthFromInput = () => {
     if (widthInput === "") {
@@ -167,6 +191,30 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
     return null;
   }
 
+  const showFilterEditor = Boolean(adjustUrlFiltersSlot && (urlTooLong || keepAdjustFiltersVisible));
+
+  const shareEmbedFilterHelp = (
+    <>
+      {urlTooLong && (
+        <p className="embed-table-modal-url-warning" role="alert">
+          This link is too long to share reliably. To shorten it, select fewer table columns, fewer years, or fewer places
+          in the geography filter.
+        </p>
+      )}
+      {showFilterEditor && (
+        <div className="embed-table-modal-overlimit-editor">
+          {!urlTooLong && (
+            <p className="embed-table-modal-url-ready" role="status">
+              This share link is within a safe length.
+            </p>
+          )}
+          <p className="embed-table-modal-overlimit-title">Adjust filters in this window</p>
+          <div className="embed-table-modal-dataset-filters">{adjustUrlFiltersSlot}</div>
+        </div>
+      )}
+    </>
+  );
+
   return (
     <div className="download-modal-overlay" role="presentation" onClick={onClose}>
       <div
@@ -209,7 +257,16 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
           {panel === "share" && (
             <div className="embed-table-modal-panel" role="tabpanel" aria-label="Share">
               <p className="embed-table-modal-section-title">Copy link to page</p>
-              <div className="download-endpoint-field" role="group" aria-label="Page link">
+              <p className="embed-table-modal-section-hint">
+                This link includes the selected filters (columns, geography, and years).
+              </p>
+              {shareEmbedFilterHelp}
+              <div
+                className={`download-endpoint-field ${urlTooLong ? "is-disabled" : ""}`}
+                role="group"
+                aria-label="Page link"
+                aria-disabled={urlTooLong}
+              >
                 <div className="download-endpoint-field-body">
                   <span className="download-endpoint-field-label">Link</span>
                   <div className="download-endpoint-field-url">{sourceUrl}</div>
@@ -217,9 +274,13 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
                 <button
                   type="button"
                   className="download-endpoint-field-copy"
-                  onClick={() => copyText(sourceUrl, "Link copied!")}
+                  onClick={() => {
+                    if (urlTooLong) return;
+                    copyText(sourceUrl, "Link copied!");
+                  }}
                   aria-label="Copy link to clipboard"
                   title="Copy URL"
+                  disabled={urlTooLong}
                 >
                   <FontAwesomeIcon icon={faClone} aria-hidden />
                 </button>
@@ -230,6 +291,10 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
           {panel === "embed" && (
             <div className="embed-table-modal-panel" role="tabpanel" aria-label="Embed">
               <p className="embed-table-modal-section-title">Copy embed code</p>
+              <p className="embed-table-modal-section-hint">
+                The embed URL updates based on the applied filters (columns, geography, and years).
+              </p>
+              {shareEmbedFilterHelp}
               <div className="embed-table-modal-group embed-table-modal-group--tight">
                 <label className="embed-table-modal-embed-size-label" htmlFor="embed-size-preset">
                   Size
@@ -282,7 +347,12 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
                   />
                 </div>
               </div>
-              <div className="download-endpoint-field" role="group" aria-label="Embed code">
+              <div
+                className={`download-endpoint-field ${urlTooLong ? "is-disabled" : ""}`}
+                role="group"
+                aria-label="Embed code"
+                aria-disabled={urlTooLong}
+              >
                 <div className="download-endpoint-field-body">
                   <span className="download-endpoint-field-label">Embed code</span>
                   <pre className="download-endpoint-field-url embed-table-modal-embed-code-content">{iframeCode}</pre>
@@ -290,9 +360,13 @@ const EmbedTableModal = ({ isOpen, onClose, datasetId, title }) => {
                 <button
                   type="button"
                   className="download-endpoint-field-copy"
-                  onClick={copyEmbedCode}
+                  onClick={() => {
+                    if (urlTooLong) return;
+                    copyEmbedCode();
+                  }}
                   aria-label="Copy embed code to clipboard"
                   title="Copy embed code"
+                  disabled={urlTooLong}
                 >
                   <FontAwesomeIcon icon={faClone} aria-hidden />
                 </button>
@@ -321,10 +395,15 @@ EmbedTableModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   title: PropTypes.string,
+  shareUrl: PropTypes.string,
+  embedUrl: PropTypes.string,
+  urlTooLong: PropTypes.bool,
+  adjustUrlFiltersSlot: PropTypes.node,
 };
 
 EmbedTableModal.defaultProps = {
   title: "",
+  urlTooLong: false,
 };
 
 export default EmbedTableModal;

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -1,13 +1,18 @@
 import React from "react";
 import axios from "axios";
 import { useSelector, useDispatch } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import { css } from "@emotion/react";
 import MoonLoader from "react-spinners/MoonLoader";
 import { fetchDatasets } from "../reducers/datasetSlice";
 import DatasetHeader from "../components/partials/DatasetHeader";
 import DatasetTable from "../components/partials/DatasetTable";
 import { isDatasetInventoryCatalog } from "../utils/datasetInventoryRow";
+import {
+  parseDatasetViewShareSearch,
+  resolveGeographiesFromUrl,
+  resolveYearsFromUrl,
+} from "../utils/datasetViewShareQuery";
 
 const override = css`
   height: 3.5rem;
@@ -252,16 +257,33 @@ class DataViewerClass extends React.Component {
           const visibleColumnKeys = this.getVisibleColumnKeys(columnKeys);
           const marginColumnsByBase = this.getMarginColumnsByBase(columnKeys);
           const selectedBaseColumns = visibleColumnKeys.map((col) => col.name);
+          let selectedColumns = this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase);
+          let selectedGeographies = availableGeographies;
+          let selectedYears = distinctYears.length ? [distinctYears[0]] : [];
+
+          const parsedShare = parseDatasetViewShareSearch(this.props.location?.search ?? "");
+          if (parsedShare.baseColumnNames?.length) {
+            const visibleSet = new Set(visibleColumnKeys.map((c) => c.name));
+            const validBases = parsedShare.baseColumnNames.filter((n) => visibleSet.has(n));
+            if (validBases.length) {
+              selectedColumns = this.expandSelectedWithMargins(validBases, marginColumnsByBase);
+            }
+          }
+          const geoOverride = resolveGeographiesFromUrl(parsedShare, availableGeographies);
+          if (geoOverride) selectedGeographies = geoOverride;
+          const yearOverride = resolveYearsFromUrl(parsedShare, distinctYears);
+          if (yearOverride) selectedYears = yearOverride;
+
           this.setState({
             availableYears: distinctYears,
             rows: tableResults,
             universe: universeData ? universeData.details : "",
             description: descriptionData ? descriptionData.details : "",
             columnKeys: columnKeys,
-            selectedColumns: this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase),
+            selectedColumns,
             marginColumnsByBase,
             metadata,
-            selectedYears: distinctYears.length ? [distinctYears[0]] : [],
+            selectedYears,
             table: dataset.table_name,
             schema: dataset.schemaname,
             database: dataset.db_name,
@@ -271,7 +293,7 @@ class DataViewerClass extends React.Component {
             updatedAt: dataset.updated,
             geographyColumn,
             availableGeographies,
-            selectedGeographies: availableGeographies, // default: show all
+            selectedGeographies,
             linkInventoryRows: isDatasetInventoryCatalog(dataset),
             loading: false,
           });
@@ -305,15 +327,29 @@ class DataViewerClass extends React.Component {
             const visibleColumnKeys = this.getVisibleColumnKeys(sortedMetadata);
             const marginColumnsByBase = this.getMarginColumnsByBase(sortedMetadata);
             const selectedBaseColumns = visibleColumnKeys.map((col) => col.name);
+            let selectedColumns = this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase);
+            let selectedYears = distinctYears.length ? [distinctYears[0]] : [];
+
+            const parsedShare = parseDatasetViewShareSearch(this.props.location?.search ?? "");
+            if (parsedShare.baseColumnNames?.length) {
+              const visibleSet = new Set(visibleColumnKeys.map((c) => c.name));
+              const validBases = parsedShare.baseColumnNames.filter((n) => visibleSet.has(n));
+              if (validBases.length) {
+                selectedColumns = this.expandSelectedWithMargins(validBases, marginColumnsByBase);
+              }
+            }
+            const yearOverride = resolveYearsFromUrl(parsedShare, distinctYears);
+            if (yearOverride) selectedYears = yearOverride;
+
             this.setState({
               availableYears: distinctYears,
               rows: tableResults,
               description: metadata.documentation.metadata.dataIdInfo.idPurp || "",
               columnKeys: sortedMetadata,
-              selectedColumns: this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase),
+              selectedColumns,
               marginColumnsByBase,
               metadata,
-              selectedYears: distinctYears.length ? [distinctYears[0]] : [],
+              selectedYears,
               table: dataset.table_name,
               schema: dataset.schemaname,
               database: dataset.db_name,
@@ -353,8 +389,7 @@ class DataViewerClass extends React.Component {
         const newArray = front.concat(back);
         return { selectedYears: newArray };
       }
-      prevState.selectedYears.push(year);
-      return { selectedYears: prevState.selectedYears };
+      return { selectedYears: [...prevState.selectedYears, year] };
     });
   }
 
@@ -470,10 +505,18 @@ class DataViewerClass extends React.Component {
 
 const DataViewerPage = () => {
   const params = useParams();
+  const location = useLocation();
   const dispatch = useDispatch();
   const datasets = useSelector((state) => state.dataset.cache);
 
-  return <DataViewerClass params={params} datasets={datasets} fetchDatasets={() => dispatch(fetchDatasets())} />;
+  return (
+    <DataViewerClass
+      params={params}
+      location={location}
+      datasets={datasets}
+      fetchDatasets={() => dispatch(fetchDatasets())}
+    />
+  );
 };
 
 export default DataViewerPage;


### PR DESCRIPTION
- Share / embed links encode the current table view (columns, geography, and years) in the URL when relevant, with a maximum length guard so very long links fail safely.
-Length warning appears inside the Share / Embed pop-up window
-In that same dialog, users can trim the URL using the same controls as the dataset table: year, column selection and geography filter
- Column and geography dropdowns each have Select all and Clear all, so users can clear everything in one step and re-pick without needing to “select all” first.
- If the URL was too long and then fits again (e.g. after adjusting filters), the inline filter area stays visible while copy is turned back on
- Share / Embed popup is wider so long URLs and iframe code are easier to read.