### PR TITLE
Add treemap and override map

### DIFF
--- a/src/assets/styles/components/CommunityProfiles.scss
+++ b/src/assets/styles/components/CommunityProfiles.scss
@@ -340,6 +340,33 @@
         border: none;
       }
     }
+
+    /* Treemap: Total Revenue column left, chart right (see TreeMap.jsx) */
+    .chart.TreeMap .treemap-layout {
+      direction: ltr;
+    }
+
+    @include media(medium-small) {
+      .chart.TreeMap .treemap-layout {
+        flex-wrap: wrap !important;
+      }
+
+      .chart.TreeMap .treemap-summary {
+        flex: 1 1 100% !important;
+        max-width: 100% !important;
+        min-width: 0 !important;
+        order: 1 !important;
+        border-right: none !important;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+        padding-bottom: 0.75rem !important;
+        margin-bottom: 0.25rem;
+      }
+
+      .chart.TreeMap .svg-wrapper {
+        flex: 1 1 100% !important;
+        order: 2 !important;
+      }
+    }
   }
 
 }

--- a/src/assets/styles/components/CommunityProfiles.scss
+++ b/src/assets/styles/components/CommunityProfiles.scss
@@ -340,33 +340,6 @@
         border: none;
       }
     }
-
-    /* Treemap: Total Revenue column left, chart right (see TreeMap.jsx) */
-    .chart.TreeMap .treemap-layout {
-      direction: ltr;
-    }
-
-    @include media(medium-small) {
-      .chart.TreeMap .treemap-layout {
-        flex-wrap: wrap !important;
-      }
-
-      .chart.TreeMap .treemap-summary {
-        flex: 1 1 100% !important;
-        max-width: 100% !important;
-        min-width: 0 !important;
-        order: 1 !important;
-        border-right: none !important;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-        padding-bottom: 0.75rem !important;
-        margin-bottom: 0.25rem;
-      }
-
-      .chart.TreeMap .svg-wrapper {
-        flex: 1 1 100% !important;
-        order: 2 !important;
-      }
-    }
   }
 
 }

--- a/src/assets/styles/components/Tab.scss
+++ b/src/assets/styles/components/Tab.scss
@@ -13,6 +13,16 @@
   &__row {
     display: flex;
     padding: 2em 8em;
+
+    &--full-width-map {
+      > .municipal-finance-overrides-map {
+        flex: 1 1 100%;
+        width: 100%;
+        max-width: 100%;
+        min-width: 0;
+        box-sizing: border-box;
+      }
+    }
     
     // For 3 charts in a row (digital equity tab)
     &:has(.chart-wrapper:nth-child(3)) {

--- a/src/assets/styles/modules/chart.scss
+++ b/src/assets/styles/modules/chart.scss
@@ -162,6 +162,16 @@
   flex: 1;
   max-width: calc(50% - 3em);
 
+  &.chart-wrapper--fund-revenue-breakdown {
+    max-width: none;
+    width: 100%;
+    flex: 1 1 100%;
+
+    &:first-child {
+      margin-right: 0;
+    }
+  }
+
   &:first-child {
     margin-right: 6em;
   }

--- a/src/assets/styles/modules/chart.scss
+++ b/src/assets/styles/modules/chart.scss
@@ -170,6 +170,33 @@
     &:first-child {
       margin-right: 0;
     }
+
+    /* treemap only:  stack summary above chart <=1200px for readable SVG */
+    .chart.TreeMap .treemap-layout {
+      direction: ltr;
+    }
+
+    @include media(large) {
+      .chart.TreeMap .treemap-layout {
+        flex-wrap: wrap !important;
+      }
+
+      .chart.TreeMap .treemap-summary {
+        flex: 1 1 100% !important;
+        max-width: 100% !important;
+        min-width: 0 !important;
+        order: 1 !important;
+        border-right: none !important;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+        padding-bottom: 0.75rem !important;
+        margin-bottom: 0.25rem;
+      }
+
+      .chart.TreeMap .svg-wrapper {
+        flex: 1 1 100% !important;
+        order: 2 !important;
+      }
+    }
   }
 
   &:first-child {

--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -452,7 +452,12 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
               </header>
               <div className="tab__row">
                 {charts["municipal-finances"]?.fund_revenue ? (
-                  <ChartDetails chart={charts["municipal-finances"].fund_revenue} muni={muni} onViewData={handleShowModal}>
+                  <ChartDetails
+                    chart={charts["municipal-finances"].fund_revenue}
+                    muni={muni}
+                    onViewData={handleShowModal}
+                    wrapperClassName="chart-wrapper--fund-revenue-breakdown"
+                  >
                     <TreeMap chart={charts["municipal-finances"].fund_revenue} muni={muni} />
                   </ChartDetails>
                 ) : null}

--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -17,6 +17,7 @@ import ChartDetails from "./visualizations/ChartDetails";
 import PieChart from "../containers/visualizations/PieChart";
 import LineChart from "../containers/visualizations/LineChart";
 import GaugeChart from "../containers/visualizations/GaugeChart";
+import TreeMap from "../containers/visualizations/TreeMap";
 import DownloadAllChartsButton from "./field/DownloadAllChartsButton";
 import DataTableModal from "./field/DataTableModal";
 import { store } from "../store";
@@ -52,14 +53,27 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
     });
   };
 
+  const getChartsForTab = (tabKey) => {
+    const tabConfig = charts[tabKey];
+    if (!tabConfig) return [];
+    // Most tabs are a map of charts; some may be a single chart object.
+    if (tabConfig.tables) return [tabConfig];
+    return Object.values(tabConfig).filter((chartConfig) => chartConfig?.tables);
+  };
+
+  const getAllChartConfigs = () =>
+    Object.values(charts).flatMap((tabConfig) => {
+      if (!tabConfig || typeof tabConfig !== "object") return [];
+      if (tabConfig.tables) return [tabConfig];
+      return Object.values(tabConfig).filter((chartConfig) => chartConfig?.tables);
+    });
+
   useEffect(() => {
     setActiveTab(tab);
   }, [tab]);
 
   useEffect(() => {
-    if (charts[activeTab]) {
-      Object.values(charts[activeTab]).forEach((chart) => dispatch(fetchChartData({ chartInfo: chart, municipality: muni })));
-    }
+    getChartsForTab(activeTab).forEach((chart) => dispatch(fetchChartData({ chartInfo: chart, municipality: muni })));
   }, [activeTab, muni, dispatch]);
 
   const handlePrintCharts = async () => {
@@ -68,11 +82,9 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
     const allTables = [];
     
     // Get all table names from charts
-    Object.values(charts).forEach((category) => {
-      Object.values(category).forEach((chartInfo) => {
-        Object.keys(chartInfo.tables).forEach((tableName) => {
-          allTables.push(tableName);
-        });
+    getAllChartConfigs().forEach((chartInfo) => {
+      Object.keys(chartInfo.tables).forEach((tableName) => {
+        allTables.push(tableName);
       });
     });
 
@@ -86,12 +98,10 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
     if (!allDataLoaded) {
       const fetchPromises = [];
       
-      Object.values(charts).forEach((category) => {
-        Object.values(category).forEach((chartInfo) => {
-          fetchPromises.push(
-            dispatch(fetchChartData({ chartInfo: chartInfo, municipality: muni }))
-          );
-        });
+      getAllChartConfigs().forEach((chartInfo) => {
+        fetchPromises.push(
+          dispatch(fetchChartData({ chartInfo, municipality: muni }))
+        );
       });
 
       // Wait for all data to be loaded
@@ -153,6 +163,33 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
         .chart-wrapper svg {
           width: 100% !important;
           height: auto !important;
+        }
+        /* Treemap needs full row in print or it gets clipped. */
+        .tab__row .chart-wrapper:has(.chart.TreeMap) {
+          width: 100% !important;
+          max-width: 100% !important;
+          padding: 0 !important;
+          page-break-inside: avoid !important;
+          break-inside: avoid !important;
+        }
+        .chart.TreeMap .svg-wrapper,
+        .chart.TreeMap svg {
+          overflow: visible !important;
+        }
+        .chart.TreeMap,
+        .chart.TreeMap * {
+          -webkit-print-color-adjust: exact !important;
+          print-color-adjust: exact !important;
+        }
+        .chart.TreeMap > div:last-child {
+          display: flex !important;
+          flex-wrap: wrap !important;
+          gap: 0.5rem 0.75rem !important;
+          margin-top: 0.1rem !important;
+          color: #111 !important;
+        }
+        .chart.TreeMap > div:last-child span[aria-hidden] {
+          border: 1px solid rgba(0, 0, 0, 0.25) !important;
         }
         .tab__row--after-gauges {
           margin-top: 2.5em !important;
@@ -407,6 +444,18 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
                     </ul>
                   </div>
                 </div>
+              </div>
+            </Tab>
+            <Tab active={activeTab === "municipal-finances"}>
+              <header className="print-header">
+                <h3>Municipal Finances</h3>
+              </header>
+              <div className="tab__row">
+                {charts["municipal-finances"]?.fund_revenue ? (
+                  <ChartDetails chart={charts["municipal-finances"].fund_revenue} muni={muni} onViewData={handleShowModal}>
+                    <TreeMap chart={charts["municipal-finances"].fund_revenue} muni={muni} />
+                  </ChartDetails>
+                ) : null}
               </div>
             </Tab>
           </div>

--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useParams, useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import Tab from "./Tab";
@@ -18,6 +18,7 @@ import PieChart from "../containers/visualizations/PieChart";
 import LineChart from "../containers/visualizations/LineChart";
 import GaugeChart from "../containers/visualizations/GaugeChart";
 import TreeMap from "../containers/visualizations/TreeMap";
+import MunicipalFinanceOverridesMap from "./visualizations/MunicipalFinanceOverridesMap";
 import DownloadAllChartsButton from "./field/DownloadAllChartsButton";
 import DataTableModal from "./field/DataTableModal";
 import { store } from "../store";
@@ -450,7 +451,7 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
                 <h3>Municipal Finances</h3>
               </header>
               <div className="tab__row">
-                {charts["municipal-finances"]?.fund_revenue ? (
+                
                   <ChartDetails
                     chart={charts["municipal-finances"].fund_revenue}
                     muni={muni}
@@ -459,8 +460,16 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
                   >
                     <TreeMap chart={charts["municipal-finances"].fund_revenue} muni={muni} />
                   </ChartDetails>
-                ) : null}
+             
               </div>
+              
+                <div className="tab__row tab__row--full-width-map">
+                  <MunicipalFinanceOverridesMap
+                    config={charts["municipal-finances"].overrides_map_config}
+                    municipalFeature={municipalFeature}
+                  />
+                </div>
+             
             </Tab>
           </div>
         </div>

--- a/src/components/field/DataTableModal.jsx
+++ b/src/components/field/DataTableModal.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { fetchTableColumnAliases } from '../visualizations/MunicipalFinanceOverridesMap';
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 
@@ -283,38 +284,7 @@ const DataTableModal = ({ show, handleClose, data, title, muni, tableKey }) => {
       const table = tableKeyStr.slice(firstDot + 1);
 
       try {
-        const res = await fetch(
-          `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(
-            table,
-          )}`,
-        );
-        if (!res.ok) {
-          throw new Error(`Metadata HTTP error: ${res.status}`);
-        }
-
-        const json = await res.json();
-        const metadataContainer = json?.data ?? json;
-
-        let metadataArray = [];
-        if (Array.isArray(metadataContainer)) {
-          metadataArray = metadataContainer;
-        } else {
-          const maybeFirst = Object.values(metadataContainer || {})[0];
-          metadataArray = Array.isArray(maybeFirst) ? maybeFirst : [];
-        }
-
-        // Fallback for nested metadata shapes (defensive)
-        if ((!metadataArray || metadataArray.length === 0) && metadataContainer?.documentation?.metadata?.eainfo?.detailed?.attr) {
-          metadataArray = metadataContainer.documentation.metadata.eainfo.detailed.attr;
-        }
-
-        const next = {};
-        metadataArray.forEach((col) => {
-          const alias = col?.alias ?? "";
-            
-          next[String(col?.name)] = alias;
-        });
-
+        const next = await fetchTableColumnAliases({ database: "ds", schema, table });
         if (!cancelled) setColumnAliasByName(next);
       } catch (err) {
         console.error("Failed to fetch column aliases for table:", tableKeyStr, err);
@@ -392,7 +362,7 @@ const DataTableModal = ({ show, handleClose, data, title, muni, tableKey }) => {
         )
       ].join('\n');
 
-      const fileName = `${title}_${muni || 'data'}.csv`.replace(/[^a-z0-9-_\.]/gi, '_');
+      const fileName = `${title}_${muni || 'data'}.csv`.replace(/[^a-z0-9._-]/gi, '_');
       const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');

--- a/src/components/field/DownloadAllChartsButton.jsx
+++ b/src/components/field/DownloadAllChartsButton.jsx
@@ -78,14 +78,24 @@ const makeSelectAllChartsData = (allTables, muni, datatype) => {
   );
 };
 
+const getAllChartConfigs = () => {
+  return Object.values(charts).flatMap((category) => {
+    if (!category || typeof category !== "object") return [];
+    // Standard tabs: { chartKey: chartConfig, ... }
+    // Some tabs may be a direct chart object with `tables`.
+    if (category.tables && typeof category.tables === "object") {
+      return [category];
+    }
+    return Object.values(category).filter((chartInfo) => chartInfo && chartInfo.tables && typeof chartInfo.tables === "object");
+  });
+};
+
 // Get all table names from charts
 const allTables = (() => {
   const tables = new Set();
-  Object.values(charts).forEach((category) => {
-    Object.values(category).forEach((chartInfo) => {
-      Object.keys(chartInfo.tables).forEach((table) => {
-        tables.add(table);
-      });
+  getAllChartConfigs().forEach((chartInfo) => {
+    Object.keys(chartInfo.tables).forEach((table) => {
+      tables.add(table);
     });
   });
   return Array.from(tables);
@@ -106,40 +116,38 @@ export default function DownloadAllChartsButton({ muni, datatype, displayName })
     let totalToFetch = 0;
     let fetched = 0;
 
-    Object.values(charts).forEach((category) => {
-      Object.values(category).forEach((chartInfo) => {
-        const needsFetch = Object.keys(chartInfo.tables).some(
-          (tableName) => !allData[tableName] || allData[tableName].length === 0
-        );
+    getAllChartConfigs().forEach((chartInfo) => {
+      const needsFetch = Object.keys(chartInfo.tables).some(
+        (tableName) => !allData[tableName] || allData[tableName].length === 0
+      );
 
-        if (needsFetch) {
-          totalToFetch++;
-          let fetchPromise;
-          switch (datatype) {
-            case 'subregion':
-              fetchPromise = dispatch(
-                fetchSubregionChartData({ subregionId: muni, chartInfo })
-              );
-              break;
-            case 'rpa':
-              fetchPromise = dispatch(
-                fetchRPAregionChartData({ rpa_id: muni, chartInfo })
-              );
-              break;
-            default:
-              fetchPromise = dispatch(
-                fetchChartData({ chartInfo, municipality: muni })
-              );
-          }
-
-          fetchPromises.push(
-            fetchPromise.then(() => {
-              fetched++;
-              setLoadingStatus(`Fetching data (${fetched}/${totalToFetch})`);
-            })
-          );
+      if (needsFetch) {
+        totalToFetch++;
+        let fetchPromise;
+        switch (datatype) {
+          case 'subregion':
+            fetchPromise = dispatch(
+              fetchSubregionChartData({ subregionId: muni, chartInfo })
+            );
+            break;
+          case 'rpa':
+            fetchPromise = dispatch(
+              fetchRPAregionChartData({ rpa_id: muni, chartInfo })
+            );
+            break;
+          default:
+            fetchPromise = dispatch(
+              fetchChartData({ chartInfo, municipality: muni })
+            );
         }
-      });
+
+        fetchPromises.push(
+          fetchPromise.then(() => {
+            fetched++;
+            setLoadingStatus(`Fetching data (${fetched}/${totalToFetch})`);
+          })
+        );
+      }
     });
 
     if (fetchPromises.length > 0) {
@@ -159,22 +167,20 @@ export default function DownloadAllChartsButton({ muni, datatype, displayName })
       const state = store.getState();
       const excelData = {};
     
-      Object.values(charts).forEach((category) => {
-        Object.values(category).forEach((chartInfo) => {
-          Object.keys(chartInfo.tables).forEach((tableName) => {
-            let data;
-            switch (datatype) {
-              case 'subregion':
-                data = state.subregion.cache[tableName]?.[muni] || [];
-                break;
-              case 'rpa':
-                data = state.rparegion.cache[tableName]?.[muni] || [];
-                break;
-              default:
-                data = state.chart.cache[tableName]?.[muni] || [];
-            }
-            excelData[tableName] = data;
-          });
+      getAllChartConfigs().forEach((chartInfo) => {
+        Object.keys(chartInfo.tables).forEach((tableName) => {
+          let data;
+          switch (datatype) {
+            case 'subregion':
+              data = state.subregion.cache[tableName]?.[muni] || [];
+              break;
+            case 'rpa':
+              data = state.rparegion.cache[tableName]?.[muni] || [];
+              break;
+            default:
+              data = state.chart.cache[tableName]?.[muni] || [];
+          }
+          excelData[tableName] = data;
         });
       });
 
@@ -212,7 +218,14 @@ export default function DownloadAllChartsButton({ muni, datatype, displayName })
     // Create a mapping of table names to their category and chart key
     const tableMapping = {};
     Object.entries(charts).forEach(([category, categoryCharts]) => {
-      Object.entries(categoryCharts).forEach(([chartKey, chart]) => {
+      if (categoryCharts?.tables && typeof categoryCharts.tables === "object") {
+        Object.keys(categoryCharts.tables).forEach((tableName) => {
+          tableMapping[tableName] = `${category}`;
+        });
+        return;
+      }
+      Object.entries(categoryCharts || {}).forEach(([chartKey, chart]) => {
+        if (!chart?.tables) return;
         Object.keys(chart.tables).forEach((tableName) => {
           tableMapping[tableName] = `${category}_${chartKey}`;
         });

--- a/src/components/field/DownloadChartImageButton.jsx
+++ b/src/components/field/DownloadChartImageButton.jsx
@@ -149,13 +149,100 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
       if (chartType === 'treemap') {
         svgHeight = Math.round(svgWidth * (440 / 760));
       }
-      
-      // Set explicit dimensions on the cloned SVG
+
+      // Set explicit dimensions on the cloned SVG before composing treemap + summary
       clonedSvg.setAttribute('width', svgWidth);
       clonedSvg.setAttribute('height', svgHeight);
       // For gauges and treemaps, keep original viewBox to avoid clipping/distortion.
       if (!isGaugeChart && chartType !== 'treemap') {
         clonedSvg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
+      }
+
+      // Fund Revenue treemap: stack summary above chart in the exported image (avoids horizontal overflow).
+      const treemapSummaryEl =
+        chartType === 'treemap' ? chartWrapper.querySelector('.treemap-summary') : null;
+      const TREEMAP_SUMMARY_GAP = 16;
+      let layoutChartWidth = svgWidth;
+      let treemapChartContent = clonedSvg;
+      let exportChartBodyHeight = svgHeight;
+
+      if (
+        chartType === 'treemap' &&
+        treemapSummaryEl &&
+        treemapSummaryEl.children.length >= 2
+      ) {
+        layoutChartWidth = svgWidth;
+
+        const labelDom = treemapSummaryEl.children[0];
+        const valueDom = treemapSummaryEl.children[1];
+        const labelCs = window.getComputedStyle(labelDom);
+        const valueCs = window.getComputedStyle(valueDom);
+
+        const pickFontFamily = (cs) => {
+          const raw = cs.fontFamily || 'Arial, sans-serif';
+          const first = raw.split(',')[0] || raw;
+          return first.replace(/["']/g, '').trim() || 'Arial';
+        };
+
+        const wrapW = Math.max(160, svgWidth - 16);
+        const valueStr = valueDom.textContent || '';
+        const valueFontSize = valueCs.fontSize || '28px';
+        const valueFontNum = parseFloat(valueFontSize) || 28;
+        const labelPx = Math.max(10, parseFloat(labelCs.fontSize) || 11);
+        const valueLines = wrapText(valueStr, wrapW);
+        const valueLineStep = Math.ceil(valueFontNum * 1.22);
+
+        const ns = 'http://www.w3.org/2000/svg';
+        const pair = document.createElementNS(ns, 'g');
+        const sumG = document.createElementNS(ns, 'g');
+
+        // `y` is the text baseline. Reserve space above the value baseline for tall digits ($),
+        // and below the label baseline for the label line box, so they never overlap.
+        const padTop = 4;
+        const labelBaseline = padTop + Math.ceil(labelPx * 1.05);
+        const tLabel = document.createElementNS(ns, 'text');
+        tLabel.setAttribute('x', '0');
+        tLabel.setAttribute('y', String(labelBaseline));
+        tLabel.setAttribute('font-family', pickFontFamily(labelCs));
+        tLabel.setAttribute('font-size', labelCs.fontSize || '11px');
+        tLabel.setAttribute('font-weight', labelCs.fontWeight || '700');
+        tLabel.setAttribute('fill', labelCs.color || '#555555');
+        if (labelCs.letterSpacing && labelCs.letterSpacing !== 'normal') {
+          tLabel.setAttribute('letter-spacing', labelCs.letterSpacing);
+        }
+        tLabel.textContent = labelDom.textContent || '';
+        sumG.appendChild(tLabel);
+
+        const labelInkBottom = labelBaseline + Math.ceil(labelPx * 0.35);
+        const labelValueGap = 14;
+        const valueCapAboveBaseline = Math.ceil(valueFontNum * 0.82);
+        let valueBaseline = labelInkBottom + labelValueGap + valueCapAboveBaseline;
+        valueLines.forEach((line) => {
+          const tVal = document.createElementNS(ns, 'text');
+          tVal.setAttribute('x', '0');
+          tVal.setAttribute('y', String(valueBaseline));
+          tVal.setAttribute('font-family', pickFontFamily(valueCs));
+          tVal.setAttribute('font-size', valueFontSize);
+          tVal.setAttribute('font-weight', valueCs.fontWeight || '800');
+          tVal.setAttribute('fill', valueCs.color || '#1F4E46');
+          tVal.textContent = line;
+          sumG.appendChild(tVal);
+          valueBaseline += valueLineStep;
+        });
+
+        const summaryBlockHeight = valueBaseline + 12;
+        pair.appendChild(sumG);
+
+        const svgBelow = document.createElementNS(ns, 'g');
+        svgBelow.setAttribute(
+          'transform',
+          `translate(0, ${summaryBlockHeight + TREEMAP_SUMMARY_GAP})`,
+        );
+        svgBelow.appendChild(clonedSvg);
+        pair.appendChild(svgBelow);
+
+        treemapChartContent = pair;
+        exportChartBodyHeight = summaryBlockHeight + TREEMAP_SUMMARY_GAP + svgHeight;
       }
       
       // Calculate legend height dynamically with better estimation
@@ -204,7 +291,7 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
       // Wrap long chart title; optionally hide title entirely.
       // Use a single, consistent wrapping rule so any long title breaks cleanly onto multiple lines.
       const rawTitle = hideTitle ? '' : (chartTitle || 'Chart Title');
-      const maxTitleWidth = Math.max(50, svgWidth - 40);
+      const maxTitleWidth = Math.max(50, layoutChartWidth - 40);
       const titleLines = rawTitle ? wrapText(rawTitle, maxTitleWidth) : [];
       const titleHeight = rawTitle ? titleLines.length * 18 : 0;
 
@@ -216,9 +303,9 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
 
       // Create a new SVG that will contain everything
       const combinedSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-      combinedSvg.setAttribute('width', svgWidth + 80); 
-      combinedSvg.setAttribute('height', svgHeight + legendHeight + metadataHeight + 30 + topPadding);
-      combinedSvg.setAttribute('viewBox', `0 0 ${svgWidth + 80} ${svgHeight + legendHeight + metadataHeight + 50 + topPadding}`);
+      combinedSvg.setAttribute('width', layoutChartWidth + 80); 
+      combinedSvg.setAttribute('height', exportChartBodyHeight + legendHeight + metadataHeight + 30 + topPadding);
+      combinedSvg.setAttribute('viewBox', `0 0 ${layoutChartWidth + 80} ${exportChartBodyHeight + legendHeight + metadataHeight + 50 + topPadding}`);
       combinedSvg.style.backgroundColor = 'white';
       
       // Add chart title (multiple lines when long), unless hidden
@@ -245,18 +332,18 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
       const chartGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
       chartGroup.setAttribute('transform', `translate(50, ${chartTop})`);
       
-      chartGroup.appendChild(clonedSvg);
+      chartGroup.appendChild(treemapChartContent);
       combinedSvg.appendChild(chartGroup);
       
       // Add legend with proper styling if it exists
       if (legend) {
         const legendGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        legendGroup.setAttribute('transform', `translate(50, ${chartTop + svgHeight + 5})`);
+        legendGroup.setAttribute('transform', `translate(50, ${chartTop + exportChartBodyHeight + 5})`);
         
         // Get legend items
         const legendItems = legend.querySelectorAll('li');
         const itemsPerRow = 2; // Fixed at 2 items per row
-        const maxWidth = svgWidth; // Use full chart width for legend
+        const maxWidth = layoutChartWidth; // Use full chart width for legend
         const itemWidth = maxWidth / itemsPerRow;
         
         // Track row heights for proper spacing
@@ -322,6 +409,68 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
         legendHeight = totalLegendHeight;
         
         combinedSvg.appendChild(legendGroup);
+      } else if (chartType === 'treemap') {
+        const treemapLegend = chartWrapper.querySelector('.treemap-legend');
+        if (treemapLegend && treemapLegend.children.length > 0) {
+          const legendGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+          legendGroup.setAttribute('transform', `translate(50, ${chartTop + exportChartBodyHeight + 5})`);
+
+          const legendEntries = Array.from(treemapLegend.children);
+          const itemsPerRow = 2;
+          const maxWidth = layoutChartWidth;
+          const itemWidth = maxWidth / itemsPerRow;
+          const rowHeights = [];
+
+          legendEntries.forEach((item, index) => {
+            const patch = item.querySelector('span[aria-hidden]');
+            const labelSpan = item.querySelector('span:not([aria-hidden])');
+            const labelText = (labelSpan && labelSpan.textContent) ? labelSpan.textContent.trim() : '';
+            const fillColor = patch
+              ? window.getComputedStyle(patch).backgroundColor || '#888888'
+              : '#888888';
+
+            const row = Math.floor(index / itemsPerRow);
+            const col = index % itemsPerRow;
+            const x = col * itemWidth;
+
+            let y = 0;
+            for (let i = 0; i < row; i += 1) {
+              y += rowHeights[i] || 18;
+            }
+
+            const swatch = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            swatch.setAttribute('x', String(x + 2));
+            swatch.setAttribute('y', String(y + 2));
+            swatch.setAttribute('width', '12');
+            swatch.setAttribute('height', '12');
+            swatch.setAttribute('rx', '2');
+            swatch.setAttribute('fill', fillColor);
+            legendGroup.appendChild(swatch);
+
+            const maxTextWidth = itemWidth - 22;
+            const wrappedLines = wrapText(labelText, maxTextWidth);
+            wrappedLines.forEach((line, lineIndex) => {
+              const textElement = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+              textElement.setAttribute('x', String(x + 18));
+              textElement.setAttribute('y', String(y + 12 + lineIndex * 14));
+              textElement.setAttribute('font-family', 'Arial, sans-serif');
+              textElement.setAttribute('font-size', '12px');
+              textElement.setAttribute('fill', '#4a4a4a');
+              textElement.textContent = line;
+              legendGroup.appendChild(textElement);
+            });
+
+            const itemHeight = Math.max(18, wrappedLines.length * 14 + 6);
+            if (!rowHeights[row] || itemHeight > rowHeights[row]) {
+              rowHeights[row] = itemHeight;
+            }
+          });
+
+          const totalLegendHeight = rowHeights.reduce((sum, height) => sum + height, 0) + 10;
+          legendHeight = totalLegendHeight;
+
+          combinedSvg.appendChild(legendGroup);
+        }
       }
       
       // Add metadata with proper styling if it exists
@@ -330,8 +479,8 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
         // Slightly tighter spacing between chart and metadata when no title is drawn (e.g., Internet Speed Test),
         // so the exported image more closely matches on-screen layout.
         const metadataYOffset = hideTitle
-          ? chartTop + svgHeight + legendHeight
-          : chartTop + svgHeight + legendHeight + 10;
+          ? chartTop + exportChartBodyHeight + legendHeight
+          : chartTop + exportChartBodyHeight + legendHeight + 10;
         metadataGroup.setAttribute('transform', `translate(50, ${metadataYOffset})`);
         
         // Get metadata sections
@@ -385,7 +534,7 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
         
         if (link) {
           // Wrap the link text to fit within the available width
-          const maxTextWidth = svgWidth - 20; // Leave some margin
+          const maxTextWidth = layoutChartWidth - 20; // Leave some margin
           const wrappedLines = wrapText(link.textContent, maxTextWidth);
           
           // Add each line of wrapped text
@@ -406,6 +555,14 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
         
         combinedSvg.appendChild(metadataGroup);
       }
+
+      // Treemap legend height is applied after root <svg> was first sized; refresh box so exports are not clipped.
+      combinedSvg.setAttribute('width', layoutChartWidth + 80);
+      combinedSvg.setAttribute('height', exportChartBodyHeight + legendHeight + metadataHeight + 30 + topPadding);
+      combinedSvg.setAttribute(
+        'viewBox',
+        `0 0 ${layoutChartWidth + 80} ${exportChartBodyHeight + legendHeight + metadataHeight + 50 + topPadding}`,
+      );
       
       // Convert SVG to string
       const svgData = new XMLSerializer().serializeToString(combinedSvg);
@@ -416,8 +573,8 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
       
       // Set high resolution canvas size (2x for retina displays)
       const scale = 2;
-      const finalWidth = (svgWidth + 80) * scale;
-      const finalHeight = (svgHeight + legendHeight + metadataHeight + 50 + topPadding) * scale;
+      const finalWidth = (layoutChartWidth + 80) * scale;
+      const finalHeight = (exportChartBodyHeight + legendHeight + metadataHeight + 50 + topPadding) * scale;
       
       canvas.width = finalWidth;
       canvas.height = finalHeight;

--- a/src/components/field/DownloadChartImageButton.jsx
+++ b/src/components/field/DownloadChartImageButton.jsx
@@ -124,6 +124,7 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
       const chartType = chartWrapper.querySelector('.StackedAreaChart') ? 'stacked-area' : 
                        chartWrapper.querySelector('.StackedBarChart') ? 'stacked-bar' : 
                        chartWrapper.querySelector('.PieChart') ? 'pie' :
+                       chartWrapper.querySelector('.TreeMap') ? 'treemap' :
                        isGaugeChart ? 'gauge' : 'other';
       
       if (legend && !isSpeedTestMetrics) {
@@ -144,12 +145,16 @@ const DownloadChartImageButton = ({ chartRef, chartTitle, muni, isSubregion, isR
       if (chartType === 'gauge') {
         svgHeight = Math.round(svgWidth * (40 / 80)); // match 80x40 viewBox ratio
       }
+      // Treemap should preserve original internal aspect ratio so tiles are not clipped.
+      if (chartType === 'treemap') {
+        svgHeight = Math.round(svgWidth * (440 / 760));
+      }
       
       // Set explicit dimensions on the cloned SVG
       clonedSvg.setAttribute('width', svgWidth);
       clonedSvg.setAttribute('height', svgHeight);
-      // For gauges, keep the original internal viewBox (80x40) so the arc looks the same as in the tab
-      if (!isGaugeChart) {
+      // For gauges and treemaps, keep original viewBox to avoid clipping/distortion.
+      if (!isGaugeChart && chartType !== 'treemap') {
         clonedSvg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
       }
       

--- a/src/components/visualizations/ChartDetails.jsx
+++ b/src/components/visualizations/ChartDetails.jsx
@@ -29,7 +29,7 @@ const ChartTitle = styled.h3`
 const ButtonGroup = styled.div`
   display: flex;
   gap: 8px;
-  flex: 3;
+  flex: ${({ $treemap }) => ($treemap ? "0 0 auto" : 3)};
 `;
 
 const ViewButton = styled.button`
@@ -82,7 +82,7 @@ const normalizeDigitalEquityTableKeyForMetadata = (tableKey) => {
   return `${schema}.${baseTable}`;
 };
 
-const ChartDetails = ({ chart, children, muni, onViewData, isSubregion, isRPAregion, displayName, hideButtons }) => {
+const ChartDetails = ({ chart, children, muni, onViewData, isSubregion, isRPAregion, displayName, hideButtons, wrapperClassName }) => {
   const [timeframe, setTimeframe] = useState(typeof chart.timeframe === 'string' ? chart.timeframe : 'Unknown');
   const chartWrapperRef = useRef(null);
 
@@ -147,7 +147,7 @@ const ChartDetails = ({ chart, children, muni, onViewData, isSubregion, isRPAreg
   const isGauge = chart.type === "gauge";
 
   return (
-    <div className="chart-wrapper" ref={chartWrapperRef}>
+    <div className={["chart-wrapper", wrapperClassName].filter(Boolean).join(" ")} ref={chartWrapperRef}>
       <ChartHeader className={isGauge ? "gauge-header" : ""}>
         <ChartTitle
           className="chart__title"
@@ -158,7 +158,7 @@ const ChartDetails = ({ chart, children, muni, onViewData, isSubregion, isRPAreg
           {isSubregion && ' (Aggregated)'}
         </ChartTitle>
         {!hideButtons && (
-          <ButtonGroup className="chart-details-buttons">
+          <ButtonGroup className="chart-details-buttons" $treemap={chart.type === "tree-map"}>
             <ViewButton
               onClick={handleViewData}
               title={`View ${isSubregion ? 'aggregated ' : ''}chart data in table format`}
@@ -252,11 +252,14 @@ ChartDetails.propTypes = {
   isRPAregion: PropTypes.bool,
   displayName: PropTypes.string,
   hideButtons: PropTypes.bool,
+  /** Extra class on the outer .chart-wrapper (e.g. layout overrides per chart). */
+  wrapperClassName: PropTypes.string,
 };
 
 ChartDetails.defaultProps = {
   isSubregion: false,
-  isRPAregion: false
+  isRPAregion: false,
+  wrapperClassName: "",
 };
 
 export default ChartDetails;

--- a/src/components/visualizations/ChartDetails.jsx
+++ b/src/components/visualizations/ChartDetails.jsx
@@ -127,10 +127,10 @@ const ChartDetails = ({ chart, children, muni, onViewData, isSubregion, isRPAreg
   const rpaCache = useSelector(selectRPAregionCache);
 
   useEffect(() => {
-    if (typeof chart.timeframe === 'function') {
-      chart.timeframe().then(setTimeframe);
+    if (typeof chart.timeframe === "function") {
+      chart.timeframe(muni).then(setTimeframe);
     }
-  }, [chart.timeframe]);
+  }, [chart.timeframe,muni]);
 
   const handleViewData = () => {
     if (isSubregion) {

--- a/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
+++ b/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
@@ -1,0 +1,735 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSelector } from "react-redux";
+import mapboxgl from "mapbox-gl";
+import "mapbox-gl/dist/mapbox-gl.css";
+import PropTypes from "prop-types";
+import { MAP_CONFIG } from "../../constants/mapConfig";
+import locations from "../../constants/locations";
+import colors from "../../constants/colors";
+import { fetchYears } from "../../constants/charts";
+
+/**
+ * Fetches column `name` → `alias` from `/api/metadata`
+ * @param {{ database?: string, schema: string, table: string }} params
+ * @returns {Promise<Record<string, string>>}
+ */
+export async function fetchTableColumnAliases(params) {
+  const { database = "ds", schema, table } = params || {};
+  if (!schema || !table) return {};
+
+  const res = await fetch(
+    `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${encodeURIComponent(database)}&schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(table)}`,
+  );
+  if (!res.ok) {
+    throw new Error(`Metadata HTTP error: ${res.status}`);
+  }
+  const json = await res.json();
+  
+  const metadataArray = metadataResponseToRowArray(json);
+
+  const next = {};
+  metadataArray.forEach((col) => {
+    const name =col.name
+    next[name] = col.alias
+  });
+  return next;
+}
+
+
+function metadataResponseToRowArray(container) {
+  if (!container) return [];
+  if (Array.isArray(container)) return container;
+  if (typeof container !== "object") return [];
+
+  const rows = Object.values(container).find((v) => Array.isArray(v));
+  if (rows) return rows;
+
+  const gis = container.documentation?.metadata?.eainfo?.detailed?.attr;
+  return Array.isArray(gis) ? gis : [];
+}
+
+mapboxgl.accessToken = MAP_CONFIG.accessToken;
+
+const FILL_LAYER_ID = "muni-finance-overrides-fill";
+const SOURCE_ID = "muni-finance-overrides";
+const SELECTED_OUTLINE_SOURCE_ID = "muni-finance-overrides-selected-outline";
+const SELECTED_LINE_LAYER_ID = "muni-finance-overrides-selected-line";
+
+function normalizeTownName(name) {
+  return String(name || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function isNullLikeAmt(v) {
+  return v == null || v === "";
+}
+
+function classifyRow(row) {
+  const winNull = isNullLikeAmt(row.win_amt);
+  const lossNull = isNullLikeAmt(row.loss_amt);
+  const win = winNull ? NaN : Number(row.win_amt);
+  const loss = lossNull ? NaN : Number(row.loss_amt);
+  const winPositive = Number.isFinite(win) && win > 0;
+  const lossPositive = Number.isFinite(loss) && loss > 0;
+
+  // success = at least one successful override (win_amt > 0), including when loss_amt > 0 as well.
+  if (winPositive) return "success";
+  if (winNull && lossPositive) return "loss_only";
+  if (winNull && lossNull) return "none_attempted";
+  if (!winPositive && lossPositive) return "loss_only";
+  return "none_attempted";
+}
+
+function formatUsd(v) {
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n)) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(n);
+}
+
+/** popup field label when metadata has no alias for this column (e.g. show "Tot Rev" style from tot_rev). */
+function popupColumnLabel(col) {
+  return String(col || "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function escapeHtmlText(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function parsePopupColumnLabels(p) {
+  const raw = p.popupLabelsJson;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) return raw;
+  if (typeof raw === "string" && raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function formatPopupCell(column, value) {
+  if (value == null || value === "") return "—";
+  if (column === "fiscal_yr") return String(value);
+  return formatUsd(value);
+}
+
+function buildRowLookup(rows, yearColumn, mapFiscalYear) {
+  const yc = yearColumn || "fiscal_yr";
+  const raw = rows || [];
+  const target = mapFiscalYear != null && mapFiscalYear !== "" ? Number(mapFiscalYear) : NaN;
+  const useTarget = Number.isFinite(target);
+
+  let candidates = raw;
+  if (useTarget) {
+    const filtered = raw.filter((row) => Number(row[yc]) === target);
+    if (filtered.length > 0) {
+      candidates = filtered;
+    }
+  }
+
+  const map = new Map();
+  candidates.forEach((row) => {
+    const key = normalizeTownName(row.muni_name);
+    if (!key) return;
+    const prev = map.get(key);
+    if (!prev) {
+      map.set(key, row);
+      return;
+    }
+    const ry = Number(row[yc]);
+    const py = Number(prev[yc]);
+    if (Number.isFinite(ry) && (!Number.isFinite(py) || ry > py)) {
+      map.set(key, row);
+    }
+  });
+  return map;
+}
+
+function legendKeyToColor(legend) {
+  return Object.fromEntries((legend || []).filter((item) => item.key && item.color).map((item) => [item.key, item.color]));
+}
+
+/** @param {GeoJSON.Geometry | null | undefined} geometry */
+function geometryToBounds(geometry) {
+  if (!geometry) return null;
+  const bounds = new mapboxgl.LngLatBounds();
+  const extendCoords = (coords) => {
+    if (!coords?.length) return;
+    if (typeof coords[0] === "number") {
+      bounds.extend(/** @type {[number, number]} */ (coords));
+    } else {
+      coords.forEach(extendCoords);
+    }
+  };
+  if (geometry.type === "Polygon") {
+    geometry.coordinates.forEach(extendCoords);
+  } else if (geometry.type === "MultiPolygon") {
+    geometry.coordinates.forEach((poly) => poly.forEach(extendCoords));
+  } else {
+    return null;
+  }
+  return bounds.isEmpty() ? null : bounds;
+}
+
+function parsePopupColumnOrder(p) {
+  const raw = p.popupColumnOrder;
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === "string" && raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function buildOverridePopupHtml(p) {
+  const displayName = String(p.popupMuniName ?? "");
+  const slug = String(p.popupMuniName || "")
+    .toLowerCase()
+  /*   .replace(/\s+/g, "-"); */
+  const profileUrl = `/profile/${slug}`;
+  const order = parsePopupColumnOrder(p);
+  const labelByCol = parsePopupColumnLabels(p);
+  const dl = order
+    .filter((col) => col && col !== "muni_name")
+    .map((col) => {
+      const alias = labelByCol[col];
+      const label = alias != null && String(alias).trim() !== "" ? String(alias).trim() : popupColumnLabel(col);
+      return `<dt style="margin:0;font-weight:600">${escapeHtmlText(label)}</dt><dd style="margin:0 0 8px">${formatPopupCell(col, p[`popup_${col}`])}</dd>`;
+    })
+    .join("");
+
+  return `
+        <div class="muni-finance-override-popup" style="font-family:skolar-sans-latin,Helvetica,sans-serif;min-width:220px;max-width:280px;padding:2px 0;line-height:1.45">
+          <strong style="font-size:15px;color:#1F4E46">${displayName}</strong>
+          <dl style="margin:10px 0 0;font-size:13px;color:#333">
+            ${dl}
+          </dl>
+          <a href="${profileUrl}" target="_blank" rel="noopener noreferrer" style="font-size:12px;color:#287CCB">View community profile</a>
+        </div>`;
+}
+
+function openOverridePopup(map, popup, properties, lngLat) {
+  if (!popup || !map || lngLat == null) return;
+  popup.remove();
+  popup.setLngLat(lngLat).setHTML(buildOverridePopupHtml(properties)).addTo(map);
+}
+
+function enrichGeojson(baseGeojson, rowByTown, mapColumns, mapFiscalYear, popupColumnLabels) {
+  if (!baseGeojson?.features) return { type: "FeatureCollection", features: [] };
+  const cols = mapColumns || [];
+  const labelsJson = JSON.stringify(popupColumnLabels && typeof popupColumnLabels === "object" ? popupColumnLabels : {});
+  const showMapYear =
+    mapFiscalYear != null &&
+    mapFiscalYear !== "" &&
+    Number.isFinite(Number(mapFiscalYear)) &&
+    cols.includes("fiscal_yr");
+
+  return {
+    type: "FeatureCollection",
+    features: baseGeojson.features.map((f) => {
+      const town = f.properties?.town;
+      const key = normalizeTownName(town);
+      const row = rowByTown.get(key);
+      const category = row ? classifyRow(row) : "no_data";
+      const props = {
+        town: f.properties?.town,
+        overrideCategory: category,
+        popupMuniName: town,
+        popupColumnOrder: JSON.stringify(cols),
+        popupLabelsJson: labelsJson,
+      };
+      for (const col of cols) {
+        props[`popup_${col}`] = row?.[col];
+      }
+      if (showMapYear) {
+        props.popup_fiscal_yr = Number(mapFiscalYear);
+      }
+      return {
+        ...f,
+        properties: props,
+      };
+    }),
+  };
+}
+
+export default function MunicipalFinanceOverridesMap({ config, municipalFeature }) {
+  const baseGeojson = useSelector((state) => state.municipality.geojson);
+  const mapContainerRef = useRef(null);
+  const mapRef = useRef(null);
+  const popupRef = useRef(null);
+  const layerHandlersRef = useRef({});
+  const [rows, setRows] = useState([]);
+  const [loadError, setLoadError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [mapReady, setMapReady] = useState(false);
+  const [fiscalYear, setFiscalYear] = useState(null);
+  const [outlineHighlightFeature, setOutlineHighlightFeature] = useState(null);
+  const [metadataPopupLabels, setMetadataPopupLabels] = useState({});
+
+  const profileTownKey = municipalFeature?.properties?.town;
+
+  const mergedPopupColumnLabels = useMemo(
+    () => ({ ...metadataPopupLabels, ...(config.popupColumnLabels || {}) }),
+    [metadataPopupLabels, config.popupColumnLabels],
+  );
+
+  const outlineSetterRef = useRef(setOutlineHighlightFeature);
+  outlineSetterRef.current = setOutlineHighlightFeature;
+
+  const ignoreNextPopupCloseRef = useRef(false);
+
+  const clearOutlineOnPopupCloseRef = useRef(() => {});
+  clearOutlineOnPopupCloseRef.current = () => {
+    if (ignoreNextPopupCloseRef.current) return;
+    setOutlineHighlightFeature(null);
+  };
+
+  const mapTitle = useMemo(() => {
+    const tpl = config.mapTitleTemplate || "2024 Municipal Override Map";
+    const y = fiscalYear != null ? String(fiscalYear) : "…";
+    return tpl.replace(/\{year\}/g, y);
+  }, [config.mapTitleTemplate, fiscalYear]);
+
+  const latestDataRef = useRef({
+    rows,
+    baseGeojson,
+    mapColumns: config.mapColumns,
+    popupColumnLabels: mergedPopupColumnLabels,
+    fiscalYear,
+    yearColumn: config.yearColumn || "fiscal_yr",
+    municipalFeature,
+  });
+  latestDataRef.current = {
+    rows,
+    baseGeojson,
+    mapColumns: config.mapColumns,
+    popupColumnLabels: mergedPopupColumnLabels,
+    fiscalYear,
+    yearColumn: config.yearColumn || "fiscal_yr",
+    municipalFeature,
+  };
+
+  const openProfilePopupForCurrentData = useCallback(() => {
+    const map = mapRef.current;
+    if (!map || !popupRef.current) return;
+    const {
+      rows: r,
+      baseGeojson: bg,
+      mapColumns: mc,
+      popupColumnLabels: pcl,
+      fiscalYear: fy,
+      yearColumn: yc,
+      municipalFeature: mf,
+    } = latestDataRef.current;
+    if (!mf?.geometry) return;
+    const rowByTown = buildRowLookup(r, yc, fy);
+    const data = enrichGeojson(bg, rowByTown, mc, fy, pcl);
+    const townName = mf.properties?.town;
+    const key = normalizeTownName(townName);
+    const match = data.features.find((f) => normalizeTownName(f.properties?.town) === key);
+    const labelsJson = JSON.stringify(pcl && typeof pcl === "object" ? pcl : {});
+    const props = match?.properties || {
+      popupMuniName: townName,
+      popupColumnOrder: JSON.stringify(mc || []),
+      popupLabelsJson: labelsJson,
+    };
+    const b = geometryToBounds(mf.geometry);
+    if (!b) return;
+    map.resize();
+    ignoreNextPopupCloseRef.current = true;
+    openOverridePopup(map, popupRef.current, props, b.getCenter());
+    requestAnimationFrame(() => {
+      ignoreNextPopupCloseRef.current = false;
+    });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setLoadError(null);
+      const yearCol = config.yearColumn || "fiscal_yr";
+      try {
+        const years = await fetchYears(config.tableSchema, config.tableName, yearCol, 1, "DESC");
+        const raw = years?.[0];
+        const y = raw != null && raw !== "" ? Number(raw) : NaN;
+        if (!Number.isFinite(y)) {
+          if (!cancelled) {
+            setFiscalYear(null);
+            setRows([]);
+            setLoadError("Could not load override data. Please try again later.");
+          }
+          return;
+        }
+        if (!cancelled) setFiscalYear(y);
+
+        const cols = config.mapColumns.join(",");
+        const url = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=${config.tableSchema}&table=${config.tableName}&columns=${cols}&filters=${yearCol}:${y}&limit=${config.fetchLimit || 500}`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const payload = (await res.json()) || {};
+        if (!cancelled) setRows(payload.rows || []);
+      } catch (e) {
+        console.error("MunicipalFinanceOverridesMap fetch failed", e);
+        if (!cancelled) {
+          setLoadError("Could not load override data. Please try again later.");
+          setRows([]);
+          setFiscalYear(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [config]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const schema = config.tableSchema;
+    const table = config.tableName;
+    if (!schema || !table) {
+      setMetadataPopupLabels({});
+      return () => {
+        cancelled = true;
+      };
+    }
+    (async () => {
+      try {
+        const labels = await fetchTableColumnAliases({ database: "ds", schema, table });
+        if (!cancelled) setMetadataPopupLabels(labels);
+      } catch (e) {
+        console.error("MunicipalFinanceOverridesMap metadata labels failed", e);
+        if (!cancelled) setMetadataPopupLabels({});
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [config.tableSchema, config.tableName]);
+
+  useEffect(() => {
+    if (!municipalFeature?.geometry) {
+      setOutlineHighlightFeature(null);
+      return;
+    }
+    setOutlineHighlightFeature({
+      type: "Feature",
+      properties: { town: municipalFeature.properties?.town },
+      geometry: municipalFeature.geometry,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by town string; geometry reference churn is noisy.
+  }, [profileTownKey]);
+
+  useEffect(() => {
+    if (!mapContainerRef.current) return undefined;
+    const map = new mapboxgl.Map({
+      container: mapContainerRef.current,
+      style: MAP_CONFIG.style,
+      dragPan: true,
+      dragRotate: false,
+    });
+    map.fitBounds(MAP_CONFIG.bounds, {
+      padding: { top: 28, bottom: 28, left: 28, right: 28 },
+      animate: false,
+    });
+    const navCfg = MAP_CONFIG.navigationControl || {};
+    map.addControl(
+      new mapboxgl.NavigationControl({
+        showCompass: navCfg.showCompass ?? false,
+        showZoom: true,
+        visualizePitch: navCfg.visualizePitch ?? false,
+      }),
+      "top-right",
+    );
+    mapRef.current = map;
+    popupRef.current = new mapboxgl.Popup({
+      closeButton: true,
+      closeOnClick: false,
+      focusAfterOpen: false,
+    });
+    popupRef.current.on("close", () => clearOutlineOnPopupCloseRef.current());
+
+    const onMouseEnter = () => {
+      map.getCanvas().style.cursor = "pointer";
+    };
+    const onMouseLeave = () => {
+      map.getCanvas().style.cursor = "";
+    };
+    const onClick = (e) => {
+      const f = e.features && e.features[0];
+      if (!f?.geometry) return;
+      if (f.geometry.type !== "Polygon" && f.geometry.type !== "MultiPolygon") return;
+      ignoreNextPopupCloseRef.current = true;
+      outlineSetterRef.current({
+        type: "Feature",
+        properties: { ...f.properties },
+        geometry: f.geometry,
+      });
+      openOverridePopup(map, popupRef.current, f.properties || {}, e.lngLat);
+      requestAnimationFrame(() => {
+        ignoreNextPopupCloseRef.current = false;
+      });
+    };
+
+    const onLoad = () => {
+      const lc = legendKeyToColor(config.legend);
+      const fillDefault = lc.no_data || "#e2e8f0";
+      const empty = { type: "FeatureCollection", features: [] };
+      map.addSource(SOURCE_ID, { type: "geojson", data: empty });
+      map.addLayer({
+        id: FILL_LAYER_ID,
+        type: "fill",
+        source: SOURCE_ID,
+        paint: {
+          "fill-color": [
+            "match",
+            ["get", "overrideCategory"],
+            "success",
+            lc.success || fillDefault,
+            "loss_only",
+            lc.loss_only || fillDefault,
+            "none_attempted",
+            lc.none_attempted || fillDefault,
+            "no_data",
+            lc.no_data || fillDefault,
+            fillDefault,
+          ],
+          "fill-opacity": 0.82,
+          "fill-outline-color": "#1f2937",
+        },
+      });
+      map.addSource(SELECTED_OUTLINE_SOURCE_ID, { type: "geojson", data: { type: "FeatureCollection", features: [] } });
+      map.addLayer({
+        id: SELECTED_LINE_LAYER_ID,
+        type: "line",
+        source: SELECTED_OUTLINE_SOURCE_ID,
+        layout: {
+          "line-join": "round",
+          "line-cap": "round",
+        },
+        paint: {
+          "line-color": colors.BRAND.BACKGROUND_DARK,
+          "line-width": 3,
+          "line-opacity": 1,
+        },
+      });
+      layerHandlersRef.current = { onMouseEnter, onMouseLeave, onClick };
+      map.on("mouseenter", FILL_LAYER_ID, onMouseEnter);
+      map.on("mouseleave", FILL_LAYER_ID, onMouseLeave);
+      map.on("click", FILL_LAYER_ID, onClick);
+      setMapReady(true);
+      requestAnimationFrame(() => {
+        map.resize();
+      });
+    };
+    map.on("load", onLoad);
+
+    return () => {
+      map.off("load", onLoad);
+      const h = layerHandlersRef.current;
+      if (h.onClick) {
+        map.off("click", FILL_LAYER_ID, h.onClick);
+        map.off("mouseenter", FILL_LAYER_ID, h.onMouseEnter);
+        map.off("mouseleave", FILL_LAYER_ID, h.onMouseLeave);
+      }
+      layerHandlersRef.current = {};
+      popupRef.current?.remove();
+      map.remove();
+      mapRef.current = null;
+      setMapReady(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- single map mount; legend colors from charts.js are static for this view.
+  }, []);
+
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+    const yearCol = config.yearColumn || "fiscal_yr";
+    const rowByTown = buildRowLookup(rows, yearCol, fiscalYear);
+    const data = enrichGeojson(baseGeojson, rowByTown, config.mapColumns, fiscalYear, mergedPopupColumnLabels);
+    const fillSrc = map.getSource(SOURCE_ID);
+    if (fillSrc) fillSrc.setData(data);
+
+    const outlineSrc = map.getSource(SELECTED_OUTLINE_SOURCE_ID);
+    if (outlineSrc) {
+      if (!outlineHighlightFeature?.geometry) {
+        outlineSrc.setData({ type: "FeatureCollection", features: [] });
+      } else {
+        outlineSrc.setData({
+          type: "FeatureCollection",
+          features: [outlineHighlightFeature],
+        });
+      }
+    }
+    map.resize();
+  }, [
+    mapReady,
+    rows,
+    baseGeojson,
+    config.mapColumns,
+    config.yearColumn,
+    fiscalYear,
+    outlineHighlightFeature,
+    mergedPopupColumnLabels,
+  ]);
+
+  useEffect(() => {
+    if (!mapReady || !outlineHighlightFeature?.geometry || !popupRef.current) return undefined;
+    const mf = municipalFeature;
+    if (!mf?.properties?.town) return undefined;
+    const outlineTown = normalizeTownName(outlineHighlightFeature.properties?.town);
+    const profileNorm = normalizeTownName(mf.properties.town);
+    if (outlineTown !== profileNorm) return undefined;
+
+    const popupTimer = window.setTimeout(() => {
+      openProfilePopupForCurrentData();
+    }, 500);
+
+    return () => {
+      if (popupTimer != null) window.clearTimeout(popupTimer);
+    };
+  }, [
+    mapReady,
+    outlineHighlightFeature,
+    rows.length,
+    municipalFeature,
+    mergedPopupColumnLabels,
+    config.popupColumnLabels,
+    openProfilePopupForCurrentData,
+  ]);
+
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !mapContainerRef.current) return undefined;
+    const map = mapRef.current;
+    const el = mapContainerRef.current;
+    const ro = new ResizeObserver(() => {
+      map.resize();
+    });
+    ro.observe(el);
+    map.resize();
+    return () => ro.disconnect();
+  }, [mapReady]);
+
+  useEffect(() => {
+    if (!mapReady || !municipalFeature?.geometry || !mapRef.current) {
+      return undefined;
+    }
+    const map = mapRef.current;
+    if (!map.isStyleLoaded()) return undefined;
+
+    const bounds = geometryToBounds(municipalFeature.geometry);
+    if (!bounds) return undefined;
+
+    map.resize();
+
+    map.fitBounds(bounds, {
+      padding: { top: 28, bottom: 28, left: 28, right: 28 },
+      maxZoom: 14,
+      duration: 0,
+    });
+  }, [mapReady, profileTownKey, municipalFeature]);
+
+  return (
+    <section className="municipal-finance-overrides-map" aria-labelledby="municipal-overrides-map-title">
+      <h4 id="municipal-overrides-map-title" className="chart__title" style={{ marginBottom: "0.75rem" }}>
+        {mapTitle}
+      </h4>
+      {loadError ? (
+        <p className="metadata" style={{ color: "#b45309" }}>
+          {loadError}
+        </p>
+      ) : null}
+      <div
+        ref={mapContainerRef}
+        style={{
+          width: "100%",
+          height: 400,
+          maxWidth: "100%",
+          border: "1px solid rgba(0,0,0,0.12)",
+          borderRadius: 4,
+          background: "#f8fafc",
+        }}
+      />
+      {loading ? (
+        <p className="metadata" style={{ marginTop: "0.5rem" }}>
+          Loading map…
+        </p>
+      ) : null}
+      <div
+        className="municipal-finance-overrides-map__legend"
+        style={{
+          marginTop: "0.75rem",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.75rem 1.25rem",
+          alignItems: "center",
+          fontSize: "0.75rem",
+          color: "#4a4a4a",
+        }}
+      >
+        {(config.legend || []).map((item) => (
+          <span key={item.key} style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem" }}>
+            <span
+              aria-hidden
+              style={{
+                width: 14,
+                height: 14,
+                borderRadius: 2,
+                background: item.color,
+                border: "1px solid rgba(0,0,0,0.15)",
+              }}
+            />
+            <span>{item.label}</span>
+          </span>
+        ))}
+      </div>
+      <p className="metadata" style={{ marginTop: "0.5rem", fontStyle: "italic" }}>
+        Click a town for total revenue, expenditures, and override amounts.
+      </p>
+    </section>
+  );
+}
+
+MunicipalFinanceOverridesMap.propTypes = {
+  municipalFeature: PropTypes.shape({
+    properties: PropTypes.object,
+    geometry: PropTypes.object,
+  }),
+  config: PropTypes.shape({
+    mapTitleTemplate: PropTypes.string.isRequired,
+    yearColumn: PropTypes.string,
+    tableSchema: PropTypes.string.isRequired,
+    tableName: PropTypes.string.isRequired,
+    mapColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+    popupColumnLabels: PropTypes.objectOf(PropTypes.string),
+    fetchLimit: PropTypes.number,
+    legend: PropTypes.arrayOf(
+      PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        color: PropTypes.string.isRequired,
+      }),
+    ),
+  }).isRequired,
+};

--- a/src/components/visualizations/TreeMap.jsx
+++ b/src/components/visualizations/TreeMap.jsx
@@ -311,7 +311,10 @@ class TreeMap extends React.Component {
           </div>
         </div>
         {tiles.length > 0 ? (
-          <div style={{ marginTop: "0.05rem", display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
+          <div
+            className="treemap-legend"
+            style={{ marginTop: "0.05rem", display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}
+          >
             {tiles.map((node) => (
               <div
                 key={node.key || node.label}

--- a/src/components/visualizations/TreeMap.jsx
+++ b/src/components/visualizations/TreeMap.jsx
@@ -32,9 +32,9 @@ export function buildTreeMapDataFromRow(metricDefs, row) {
     .filter((d) => d.value != null);
 }
 
-function normalizeTreeData(data) {
-  if (!Array.isArray(data)) return [];
-  return data
+function partitionTreeData(data) {
+  if (!Array.isArray(data)) return { tiles: [], summary: null };
+  const normalized = data
     .map((d) => {
       const rawValue = d.value ?? d.y;
       const parsedValue = typeof rawValue === "number" ? rawValue : Number(rawValue);
@@ -43,29 +43,56 @@ function normalizeTreeData(data) {
         label: d.label || d.key || d.id || "Unknown",
         group: d.group || "Value",
         value: parsedValue,
+        summaryOnly: Boolean(d.summaryOnly),
       };
     })
-    .filter((d) => d.key && Number.isFinite(d.value) && d.value >= 0);
+    .filter((d) => {
+      if (d.summaryOnly) {
+        return Boolean(d.key) && Number.isFinite(d.value);
+      }
+      return Boolean(d.key) && Number.isFinite(d.value) && d.value >= 0;
+    });
+  const summary = normalized.find((d) => d.summaryOnly) || null;
+  const tiles = normalized.filter((d) => !d.summaryOnly);
+  return { tiles, summary };
 }
 
-function createColorHelpers(data) {
-  const parentColor = colors.CHART.PRIMARY.get("DARK_GREEN");
-  const childColor = colors.BRAND.SECONDARY;
-  const isParentNode = (datum) => /total revenues?/i.test(String(datum?.label || ""));
+function createColorHelpers(tileData, chart) {
+  const primaryColors = Array.from(colors.CHART.PRIMARY.values());
+  const fromConfig =
+    chart && Array.isArray(chart.colors) && chart.colors.length > 0 ? chart.colors : null;
+  const palette = fromConfig
+    ? fromConfig
+    : primaryColors.length >= 4
+      ? primaryColors.slice(-4)
+      : primaryColors.length > 0
+        ? primaryColors
+        : [colors.BRAND.SECONDARY];
+  const colorScale = d3
+    .scaleOrdinal()
+    .domain((tileData || []).map((d) => String(d.key || d.label || "")))
+    .range(palette);
 
   const getFillColor = (datum) => {
-    return isParentNode(datum) ? parentColor : childColor;
+    return colorScale(String(datum?.key || datum?.label || ""));
   };
 
   const getTextColor = () => "#ffffff";
 
-  return { parentColor, childColor, getFillColor, getTextColor };
+  return { getFillColor, getTextColor };
 }
 
 class TreeMap extends React.Component {
   constructor(props) {
     super(props);
     this.chartRef = React.createRef();
+  }
+
+  resolveValueFormatter() {
+    const { valueFormatter, chart } = this.props;
+    if (typeof valueFormatter === "function") return valueFormatter;
+    if (chart && typeof chart.valueFormatter === "function") return chart.valueFormatter;
+    return d3.format(",");
   }
 
   componentDidMount() {
@@ -123,25 +150,21 @@ class TreeMap extends React.Component {
     const margin = defaultMargin;
     const width = container.width - margin.left - margin.right;
     const height = container.height - margin.top - margin.bottom;
-    const data = normalizeTreeData(this.props.data);
+    const { tiles } = partitionTreeData(this.props.data);
 
-    if (!this.props.hasData || data.length === 0) {
+    if (!this.props.hasData || tiles.length === 0) {
       this.renderBlankChart(container.width, container.height);
       return;
     }
 
     // Visual-only sizing tweaks for readability balance:
     // compress big-value dominance so smaller categories remain visible in print and screen.
-    const layoutData = data.map((d) => ({
+    const layoutData = tiles.map((d) => ({
       ...d,
       layoutValue: (() => {
         const label = String(d.label || "");
         const compressed = Math.pow(Math.max(d.value, 0), 0.65);
-        if (/total revenues?/i.test(label)) {
-          // Parent node should remain visually dominant.
-          return Math.max(compressed * 1.35, 20);
-        }
-        // Keep non-parent categories visible even when values are small or zero.
+        // Keep categories visible even when values are small or zero.
         const boosted = /all other/i.test(label) ? compressed * 1.35 : compressed;
         return Math.max(boosted, 10);
       })(),
@@ -154,9 +177,9 @@ class TreeMap extends React.Component {
 
     d3.treemap().size([width, height]).paddingInner(4).paddingOuter(2)(root);
 
-    const { getFillColor, getTextColor } = createColorHelpers(data);
+    const { getFillColor, getTextColor } = createColorHelpers(tiles);
 
-    const formatValue = this.props.valueFormatter || d3.format(",");
+    const formatValue = this.resolveValueFormatter();
 
     this.chart.selectAll("*").remove();
     const g = this.chart.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
@@ -172,7 +195,9 @@ class TreeMap extends React.Component {
       .attr("stroke-width", 1)
       .on("mouseover", (event, d) => {
         this.tooltip
-          .html(`<div><strong>${d.data.label}</strong><br/>${formatValue(d.data.value)}</div>`)
+          .html(
+            `<div style="font-size:13px;line-height:1.35"><strong>${d.data.label}</strong><br/>${formatValue(d.data.value)}</div>`,
+          )
           .style("opacity", 1)
           .style("left", `${event.pageX + 10}px`)
           .style("top", `${event.pageY - 10}px`);
@@ -185,47 +210,118 @@ class TreeMap extends React.Component {
       });
 
     leaves
-      .filter((d) => d.x1 - d.x0 >= 22 && d.y1 - d.y0 >= 14)
+      .filter((d) => d.x1 - d.x0 >= 28 && d.y1 - d.y0 >= 18)
       .append("text")
       .attr("x", 8)
-      .attr("y", 14)
-      .style("font-size", "10px")
+      .attr("y", 18)
+      .style("font-size", "13px")
       .style("font-weight", 600)
       .style("fill", (d) => getTextColor(d.data))
       .style("pointer-events", "none")
       .text((d) => {
-        const maxChars = Math.max(3, Math.floor((d.x1 - d.x0 - 12) / 6));
+        const maxChars = Math.max(3, Math.floor((d.x1 - d.x0 - 14) / 7));
         return d.data.label.length > maxChars ? `${d.data.label.slice(0, maxChars - 1)}…` : d.data.label;
       });
 
     leaves
-      .filter((d) => d.x1 - d.x0 >= 70 && d.y1 - d.y0 >= 42)
+      .filter((d) => d.x1 - d.x0 >= 88 && d.y1 - d.y0 >= 50)
       .append("text")
       .attr("x", 8)
-      .attr("y", 34)
-      .style("font-size", "11px")
+      .attr("y", 42)
+      .style("font-size", "15px")
+      .style("font-weight", 500)
       .style("fill", (d) => getTextColor(d.data))
       .style("pointer-events", "none")
       .text((d) => formatValue(d.data.value));
   }
 
   render() {
-    const data = normalizeTreeData(this.props.data);
-    const { getFillColor } = createColorHelpers(data);
+    const { tiles, summary } = partitionTreeData(this.props.data);
+    const { getFillColor } = createColorHelpers(tiles, this.props.chart);
+    const formatBig = this.resolveValueFormatter();
     return (
       <div className="component chart TreeMap">
-        <div className="svg-wrapper" style={{ display: "flex", justifyContent: "center", marginBottom: 0 }}>
-          <svg ref={this.chartRef} style={{ display: "block", width: "100%", maxWidth: "100%", height: "300px" }} />
+        <div
+          className="treemap-layout"
+          dir="ltr"
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            flexWrap: "nowrap",
+            alignItems: "stretch",
+            gap: "1.25rem",
+            width: "100%",
+            marginBottom: 0,
+          }}
+        >
+          {summary ? (
+            <div
+              className="treemap-summary"
+              style={{
+                order: 1,
+                flex: "0 0 300px",
+                maxWidth: "48%",
+                minWidth: "220px",
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "center",
+                padding: "8px 1rem 8px 0",
+                margin: 0,
+                borderLeft: "none",
+                borderRight: "1px solid rgba(0, 0, 0, 0.12)",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: "0.7rem",
+                  fontWeight: 700,
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                  color: "#555",
+                  marginBottom: "6px",
+                }}
+              >
+                {summary.label}
+              </div>
+              <div
+                style={{
+                  fontSize: "clamp(1.5rem, 3.6vw, 2.25rem)",
+                  fontWeight: 800,
+                  lineHeight: 1.15,
+                  color: colors.BRAND.BACKGROUND_DARK,
+                  wordBreak: "break-word",
+                }}
+              >
+                {formatBig(summary.value)}
+              </div>
+            </div>
+          ) : null}
+          <div
+            className="svg-wrapper"
+            style={{
+              order: 2,
+              flex: "1 1 0%",
+              minWidth: 0,
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "stretch",
+            }}
+          >
+            <svg ref={this.chartRef} style={{ display: "block", width: "100%", maxWidth: "100%", height: "320px" }} />
+          </div>
         </div>
-        {data.length > 0 ? (
+        {tiles.length > 0 ? (
           <div style={{ marginTop: "0.05rem", display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
-            {data.map((node) => (
-              <div key={node.key || node.label} style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem", color: "#4a4a4a", fontSize: "0.85rem" }}>
+            {tiles.map((node) => (
+              <div
+                key={node.key || node.label}
+                style={{ display: "inline-flex", alignItems: "center", gap: "0.4rem", color: "#4a4a4a" }}
+              >
                 <span
                   aria-hidden
                   style={{
-                    width: "10px",
-                    height: "10px",
+                    width: "12px",
+                    height: "12px",
                     borderRadius: "2px",
                     display: "inline-block",
                     background: getFillColor(node),
@@ -258,6 +354,7 @@ TreeMap.propTypes = {
 TreeMap.defaultProps = {
   hasData: true,
   valueFormatter: null,
+  chart: null,
 };
 
 export default TreeMap;

--- a/src/components/visualizations/TreeMap.jsx
+++ b/src/components/visualizations/TreeMap.jsx
@@ -1,0 +1,263 @@
+import React from "react";
+import PropTypes from "prop-types";
+import * as d3 from "d3";
+import colors from "../../constants/colors";
+
+const container = {
+  width: 760,
+  height: 350,
+};
+
+const defaultMargin = {
+  top: 20,
+  right: 20,
+  bottom: 4,
+  left: 20,
+};
+
+/**
+ * Utility for chart transformers:
+ * - metricDefs: [{ key, label, group }]
+ * - row: object with numeric values for each key (e.g. row.tot_rev)
+ */
+export function buildTreeMapDataFromRow(metricDefs, row) {
+  if (!Array.isArray(metricDefs) || !row) return [];
+  return metricDefs
+    .map((metric) => ({
+      key: metric.key,
+      label: metric.label || metric.key,
+      group: metric.group || "Value",
+      value: row[metric.key],
+    }))
+    .filter((d) => d.value != null);
+}
+
+function normalizeTreeData(data) {
+  if (!Array.isArray(data)) return [];
+  return data
+    .map((d) => {
+      const rawValue = d.value ?? d.y;
+      const parsedValue = typeof rawValue === "number" ? rawValue : Number(rawValue);
+      return {
+        key: d.key || d.id || d.label,
+        label: d.label || d.key || d.id || "Unknown",
+        group: d.group || "Value",
+        value: parsedValue,
+      };
+    })
+    .filter((d) => d.key && Number.isFinite(d.value) && d.value >= 0);
+}
+
+function createColorHelpers(data) {
+  const parentColor = colors.CHART.PRIMARY.get("DARK_GREEN");
+  const childColor = colors.BRAND.SECONDARY;
+  const isParentNode = (datum) => /total revenues?/i.test(String(datum?.label || ""));
+
+  const getFillColor = (datum) => {
+    return isParentNode(datum) ? parentColor : childColor;
+  };
+
+  const getTextColor = () => "#ffffff";
+
+  return { parentColor, childColor, getFillColor, getTextColor };
+}
+
+class TreeMap extends React.Component {
+  constructor(props) {
+    super(props);
+    this.chartRef = React.createRef();
+  }
+
+  componentDidMount() {
+    const { width, height } = container;
+    this.chart = d3
+      .select(this.chartRef.current)
+      .attr("preserveAspectRatio", "xMinYMin meet")
+      .attr("viewBox", `0 0 ${width} ${height}`)
+      .attr("width", width)
+      .attr("height", height);
+
+    this.tooltip = d3
+      .select("body")
+      .append("div")
+      .attr("class", "chart-tooltip")
+      .style("opacity", 0)
+      .style("position", "absolute")
+      .style("pointer-events", "none")
+      .style("background", "white")
+      .style("padding", "6px 8px")
+      .style("border", "1px solid #ccc")
+      .style("border-radius", "3px")
+      .style("z-index", 1000);
+
+    this.renderChart();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (JSON.stringify(prevProps.data) !== JSON.stringify(this.props.data) || prevProps.hasData !== this.props.hasData) {
+      this.renderChart();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.tooltip) {
+      this.tooltip.remove();
+    }
+    if (this.chart) {
+      this.chart.selectAll("*").remove();
+    }
+  }
+
+  renderBlankChart(width, height) {
+    this.chart.selectAll("*").remove();
+    this.chart
+      .append("text")
+      .attr("class", "missing-data")
+      .attr("x", width / 2)
+      .attr("y", height / 2)
+      .style("text-anchor", "middle")
+      .text("Data not available.");
+  }
+
+  renderChart() {
+    const margin = defaultMargin;
+    const width = container.width - margin.left - margin.right;
+    const height = container.height - margin.top - margin.bottom;
+    const data = normalizeTreeData(this.props.data);
+
+    if (!this.props.hasData || data.length === 0) {
+      this.renderBlankChart(container.width, container.height);
+      return;
+    }
+
+    // Visual-only sizing tweaks for readability balance:
+    // compress big-value dominance so smaller categories remain visible in print and screen.
+    const layoutData = data.map((d) => ({
+      ...d,
+      layoutValue: (() => {
+        const label = String(d.label || "");
+        const compressed = Math.pow(Math.max(d.value, 0), 0.65);
+        if (/total revenues?/i.test(label)) {
+          // Parent node should remain visually dominant.
+          return Math.max(compressed * 1.35, 20);
+        }
+        // Keep non-parent categories visible even when values are small or zero.
+        const boosted = /all other/i.test(label) ? compressed * 1.35 : compressed;
+        return Math.max(boosted, 10);
+      })(),
+    }));
+
+    const root = d3
+      .hierarchy({ children: layoutData })
+      .sum((d) => d.layoutValue || d.value)
+      .sort((a, b) => b.value - a.value);
+
+    d3.treemap().size([width, height]).paddingInner(4).paddingOuter(2)(root);
+
+    const { getFillColor, getTextColor } = createColorHelpers(data);
+
+    const formatValue = this.props.valueFormatter || d3.format(",");
+
+    this.chart.selectAll("*").remove();
+    const g = this.chart.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+
+    const leaves = g.selectAll("g.node").data(root.leaves()).join("g").attr("class", "node").attr("transform", (d) => `translate(${d.x0},${d.y0})`);
+
+    leaves
+      .append("rect")
+      .attr("width", (d) => Math.max(0, d.x1 - d.x0))
+      .attr("height", (d) => Math.max(0, d.y1 - d.y0))
+      .attr("fill", (d) => getFillColor(d.data))
+      .attr("stroke", "#fff")
+      .attr("stroke-width", 1)
+      .on("mouseover", (event, d) => {
+        this.tooltip
+          .html(`<div><strong>${d.data.label}</strong><br/>${formatValue(d.data.value)}</div>`)
+          .style("opacity", 1)
+          .style("left", `${event.pageX + 10}px`)
+          .style("top", `${event.pageY - 10}px`);
+      })
+      .on("mousemove", (event) => {
+        this.tooltip.style("left", `${event.pageX + 10}px`).style("top", `${event.pageY - 10}px`);
+      })
+      .on("mouseout", () => {
+        this.tooltip.style("opacity", 0);
+      });
+
+    leaves
+      .filter((d) => d.x1 - d.x0 >= 22 && d.y1 - d.y0 >= 14)
+      .append("text")
+      .attr("x", 8)
+      .attr("y", 14)
+      .style("font-size", "10px")
+      .style("font-weight", 600)
+      .style("fill", (d) => getTextColor(d.data))
+      .style("pointer-events", "none")
+      .text((d) => {
+        const maxChars = Math.max(3, Math.floor((d.x1 - d.x0 - 12) / 6));
+        return d.data.label.length > maxChars ? `${d.data.label.slice(0, maxChars - 1)}…` : d.data.label;
+      });
+
+    leaves
+      .filter((d) => d.x1 - d.x0 >= 70 && d.y1 - d.y0 >= 42)
+      .append("text")
+      .attr("x", 8)
+      .attr("y", 34)
+      .style("font-size", "11px")
+      .style("fill", (d) => getTextColor(d.data))
+      .style("pointer-events", "none")
+      .text((d) => formatValue(d.data.value));
+  }
+
+  render() {
+    const data = normalizeTreeData(this.props.data);
+    const { getFillColor } = createColorHelpers(data);
+    return (
+      <div className="component chart TreeMap">
+        <div className="svg-wrapper" style={{ display: "flex", justifyContent: "center", marginBottom: 0 }}>
+          <svg ref={this.chartRef} style={{ display: "block", width: "100%", maxWidth: "100%", height: "300px" }} />
+        </div>
+        {data.length > 0 ? (
+          <div style={{ marginTop: "0.05rem", display: "flex", gap: "0.75rem", flexWrap: "wrap", alignItems: "center" }}>
+            {data.map((node) => (
+              <div key={node.key || node.label} style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem", color: "#4a4a4a", fontSize: "0.85rem" }}>
+                <span
+                  aria-hidden
+                  style={{
+                    width: "10px",
+                    height: "10px",
+                    borderRadius: "2px",
+                    display: "inline-block",
+                    background: getFillColor(node),
+                  }}
+                />
+                <span>{node.label}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+}
+
+TreeMap.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      label: PropTypes.string,
+      group: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+      y: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    }),
+  ).isRequired,
+  hasData: PropTypes.bool,
+  valueFormatter: PropTypes.func,
+};
+
+TreeMap.defaultProps = {
+  hasData: true,
+  valueFormatter: null,
+};
+
+export default TreeMap;

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2784,4 +2784,66 @@ SELECT CONCAT(MIN(cal_year), '-', MAX(cal_year)) AS latest_year FROM years;`;
       },
     },
   },
+  "municipal-finances": {
+    fund_revenue:{
+      type: "tree-map",
+      title: "Fund Revenue Breakdown",
+      tooltip: { type: "percentAndCount" },
+      tables: {
+        "tabular.muni_finance_m": (() => {
+          const columnList = ["fiscal_yr", "tot_rev", "tax_levy", "state_aid", "loc_recpts", "all_other"];
+          return {
+            yearCol: "fiscal_yr",
+            latestYearOnly: true,
+            columns: columnList,
+            specialFetch: async (municipality, dispatchUpdate) => {
+              const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
+              const muniName = String(municipality || "").replace(/'/g, "''");
+              const selectList = columnList.join(",");
+              const queryString = `
+                SELECT ${selectList}
+                FROM tabular.muni_finance_m
+                WHERE muni_name ILIKE '${muniName}'
+                  AND fiscal_yr = (
+                    SELECT MAX(fiscal_yr)
+                    FROM tabular.muni_finance_m
+                    WHERE muni_name ILIKE '${muniName}'
+                  )
+              `;
+              const response = await fetch(`${api}${queryString}`);
+              if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+              }
+              const payload = (await response.json()) || {};
+              dispatchUpdate(payload.rows || []);
+            },
+          };
+        })(),
+      },
+      timeframe: async () => {
+        let queryString = `SELECT fiscal_yr as latest_year FROM tabular.muni_finance_m GROUP BY fiscal_yr ORDER BY fiscal_yr DESC LIMIT 1`;
+        const years = await fetchLatestYear(queryString);
+        return years[0];
+      },
+      transformer: (tables, chart) => {
+        const data = tables["tabular.muni_finance_m"];
+        if (!data || data.length < 1) {
+          return [];
+        }
+        const row = data[0];
+        return [{ value: row.tot_rev, label: "Total Revenues", group: "Fund Revenue" }, 
+          { value: row.tax_levy, label: "Tax Levy", group: "Fund Revenue" }, 
+          { value: row.state_aid, label: "State Aid", group: "Fund Revenue" }, 
+          { value: row.loc_recpts, label: "Local Receipt", group: "Fund Revenue" }, 
+          { value: row.all_other, label: "All Other", group: "Fund Revenue" }];
+      },
+      source:"MA Dept of Revenue",
+      datasetLinks: { "Dept of Revenue Municipal Finance": 502 },
+      xAxis: {
+        label: "Fund Revenue",
+        format: format.string.default,
+      },
+    }
+ 
+  },
 };

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -21,11 +21,15 @@ const format = {
   },
 };
 
-const fetchYears = async (schema, table, yearCol, limit, orderDir = 'DESC') => {
+const fetchYears = async (schema, table, yearCol, limit, orderDir = "DESC", extraQueryParams = "") => {
   const tabular_api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=${schema}&table=${table}`;
   let query = `${tabular_api}&columns=DISTINCT(${yearCol}) as latest_year&orderByColumn=${yearCol}&orderByDirection=${orderDir}`;
   if (limit) {
     query = `${query}&limit=${limit}`;
+  }
+  if (extraQueryParams) {
+    const suffix = extraQueryParams.startsWith("&") ? extraQueryParams : `&${extraQueryParams}`;
+    query = `${query}${suffix}`;
   }
 
   try {
@@ -2350,9 +2354,8 @@ export default {
         })(),
       },
       timeframe: async () => {
-        let queryString = `SELECT fiscal_yr as latest_year FROM tabular.muni_finance_m GROUP BY fiscal_yr ORDER BY fiscal_yr DESC LIMIT 1`;
-        const years = await fetchLatestYear(queryString);
-        return years[0];
+        const years = await fetchYears("tabular", "muni_finance_m", "fiscal_yr", 1, "DESC");
+        return years && years[0] ? String(years[0]) : "";
       },
       transformer: (tables) => {
         const data = tables["tabular.muni_finance_m"];

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2788,6 +2788,16 @@ SELECT CONCAT(MIN(cal_year), '-', MAX(cal_year)) AS latest_year FROM years;`;
     fund_revenue:{
       type: "tree-map",
       title: "Fund Revenue Breakdown",
+      colors: Array.from(colors.CHART.PRIMARY.values()).slice(-4),
+      valueFormatter: (v) => {
+        const n = typeof v === "number" ? v : Number(v);
+        if (!Number.isFinite(n)) return v == null || v === "" ? "" : String(v);
+        return new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+          maximumFractionDigits: 0,
+        }).format(n);
+      },
       tooltip: { type: "percentAndCount" },
       tables: {
         "tabular.muni_finance_m": (() => {
@@ -2825,17 +2835,24 @@ SELECT CONCAT(MIN(cal_year), '-', MAX(cal_year)) AS latest_year FROM years;`;
         const years = await fetchLatestYear(queryString);
         return years[0];
       },
-      transformer: (tables, chart) => {
+      transformer: (tables) => {
         const data = tables["tabular.muni_finance_m"];
         if (!data || data.length < 1) {
           return [];
         }
         const row = data[0];
-        return [{ value: row.tot_rev, label: "Total Revenues", group: "Fund Revenue" }, 
-          { value: row.tax_levy, label: "Tax Levy", group: "Fund Revenue" }, 
-          { value: row.state_aid, label: "State Aid", group: "Fund Revenue" }, 
-          { value: row.loc_recpts, label: "Local Receipt", group: "Fund Revenue" }, 
-          { value: row.all_other, label: "All Other", group: "Fund Revenue" }];
+        const totRev = row.tot_rev != null && row.tot_rev !== "" ? Number(row.tot_rev) : NaN;
+        const summaryRow =
+          Number.isFinite(totRev)
+            ? [{ summaryOnly: true, key: "tot_rev_display", label: "Total Revenue", value: totRev, group: "Fund Revenue" }]
+            : [];
+        return [
+          ...summaryRow,
+          { key: "tax_levy", value: Number(row.tax_levy), label: "Tax Levy", group: "Fund Revenue" },
+          { key: "state_aid", value: Number(row.state_aid), label: "State Aid", group: "Fund Revenue" },
+          { key: "loc_recpts", value: Number(row.loc_recpts), label: "Local Receipt", group: "Fund Revenue" },
+          { key: "all_other", value: Number(row.all_other), label: "All Other", group: "Fund Revenue" },
+        ];
       },
       source:"MA Dept of Revenue",
       datasetLinks: { "Dept of Revenue Municipal Finance": 502 },

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -21,7 +21,7 @@ const format = {
   },
 };
 
-const fetchYears = async (schema, table, yearCol, limit, orderDir = "DESC", extraQueryParams = "") => {
+export const fetchYears = async (schema, table, yearCol, limit, orderDir = "DESC", extraQueryParams = "") => {
   const tabular_api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=${schema}&table=${table}`;
   let query = `${tabular_api}&columns=DISTINCT(${yearCol}) as latest_year&orderByColumn=${yearCol}&orderByDirection=${orderDir}`;
   if (limit) {
@@ -2308,6 +2308,8 @@ export default {
     },
   },
   "municipal-finances": {
+    
+    
     fund_revenue:{
       type: "tree-map",
       title: "Fund Revenue Breakdown",
@@ -2382,7 +2384,35 @@ export default {
         label: "Fund Revenue",
         format: format.string.default,
       },
+    },overrides_map_config: {
+      mapTitleTemplate: "2024 Municipal Override Map",
+      yearColumn: "fiscal_yr",
+      tableSchema: "tabular",
+      tableName: "muni_finance_m",
+      mapColumns: ["muni_name", "fiscal_yr", "tot_rev", "total_exp", "win_amt", "loss_amt"],
+    
+      legend: [
+        {
+          key: "success",
+          label: "Successful override",
+          color: colors.CHART.EXTENDED.get("GREEN"),
+        },
+        {
+          key: "loss_only",
+          label: "No successful override",
+          color: colors.CHART.EXTENDED.get("LIGHT_PINK"),
+        },
+        {
+          key: "none_attempted",
+          label: "No override amounts reported",
+          color: colors.CHART.PRIMARY.get("LIGHT_BLUE"),
+        },
+        {
+          key: "no_data",
+          label: "No data",
+          color: "#cdcdcd",
+        },
+      ],
     }
- 
   },
 };

--- a/src/constants/tabs.js
+++ b/src/constants/tabs.js
@@ -25,6 +25,9 @@ const tabs = [{
 }, {
   value: 'digital-equity',
   label: 'Digital Equity',
+}, {
+  value: 'municipal-finances',
+  label: 'Municipal Finances',
 }];
 
 export default tabs;

--- a/src/containers/visualizations/TreeMap.js
+++ b/src/containers/visualizations/TreeMap.js
@@ -1,0 +1,59 @@
+import { connect } from "react-redux";
+import TreeMap from "../../components/visualizations/TreeMap";
+
+function valuesHaveData(transformedData) {
+  if (!transformedData || !Array.isArray(transformedData) || transformedData.length === 0) {
+    return false;
+  }
+  return transformedData.some((row) => {
+    const raw = row.value ?? row.y;
+    const value = typeof raw === "number" ? raw : Number(raw);
+    return Number.isFinite(value) && value > 0;
+  });
+}
+
+const mapStateToProps = (state, props) => {
+  const { muni, chart, isSubregion, isRPAregion } = props;
+  const tables = Object.keys(chart.tables);
+
+  if (isSubregion) {
+    if (tables.every((table) => state.subregion.cache[table] && state.subregion.cache[table][muni])) {
+      const subregionTables = tables.reduce((acc, table) => Object.assign(acc, { [table]: state.subregion.cache[table][muni] }), {});
+      const transformedData = chart.transformer(subregionTables, chart);
+      return {
+        ...props,
+        data: transformedData,
+        hasData: valuesHaveData(transformedData),
+      };
+    }
+  } else if (isRPAregion) {
+    if (tables.every((table) => state.rparegion.cache[table] && state.rparegion.cache[table][muni])) {
+      const rpaTables = tables.reduce((acc, table) => Object.assign(acc, { [table]: state.rparegion.cache[table][muni] }), {});
+      const transformedData = chart.transformer(rpaTables, chart);
+      return {
+        ...props,
+        data: transformedData,
+        hasData: valuesHaveData(transformedData),
+      };
+    }
+  } else if (tables.every((table) => state.chart.cache[table] && state.chart.cache[table][muni] && Array.isArray(state.chart.cache[table][muni]) && state.chart.cache[table][muni].length > 0)) {
+    const muniTables = tables.reduce((acc, table) => Object.assign(acc, { [table]: state.chart.cache[table][muni] }), {});
+    const transformedData = chart.transformer(muniTables, chart);
+    return {
+      ...props,
+      data: transformedData,
+      hasData: valuesHaveData(transformedData),
+    };
+  }
+
+  return {
+    ...props,
+    data: [],
+    hasData: false,
+  };
+};
+
+const mapDispatchToProps = () => ({});
+
+export default connect(mapStateToProps, mapDispatchToProps)(TreeMap);
+export { valuesHaveData };


### PR DESCRIPTION
Below treemap, there’s a full-width Municipal Override Map of Massachusetts towns. Colors show override outcomes for the latest fiscal year in the data (green = at least one successful override, pink = no successful override, light blue = no override amounts in the data, gray = no row for that town).
When user click a muni on map, a popup will show revenue, expenditures, and override amounts for clicked municipality.