### PR TITLE
Uses a standard metadata format for all datasets

### DIFF
--- a/src/components/field/DataTableModal.jsx
+++ b/src/components/field/DataTableModal.jsx
@@ -284,9 +284,7 @@ const DataTableModal = ({ show, handleClose, data, title, muni, tableKey }) => {
 
       try {
         const res = await fetch(
-          `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(
-            table,
-          )}`,
+          `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(table)}&useNewMetadata=true`,
         );
         if (!res.ok) {
           throw new Error(`Metadata HTTP error: ${res.status}`);
@@ -301,11 +299,6 @@ const DataTableModal = ({ show, handleClose, data, title, muni, tableKey }) => {
         } else {
           const maybeFirst = Object.values(metadataContainer || {})[0];
           metadataArray = Array.isArray(maybeFirst) ? maybeFirst : [];
-        }
-
-        // Fallback for nested metadata shapes (defensive)
-        if ((!metadataArray || metadataArray.length === 0) && metadataContainer?.documentation?.metadata?.eainfo?.detailed?.attr) {
-          metadataArray = metadataContainer.documentation.metadata.eainfo.detailed.attr;
         }
 
         const next = {};

--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -841,7 +841,6 @@ function DatasetHeader({
         datasetId={datasetId}
         title={title}
         table={table}
-        description={description}
         database={database}
         schema={schema}
         metadata={metadata}

--- a/src/components/partials/DatasetTable.jsx
+++ b/src/components/partials/DatasetTable.jsx
@@ -130,7 +130,6 @@ class DatasetTable extends React.Component {
     const { 
       columnKeys = [],
       currentPage = 1,
-      metadata = [],
       queryYearColumn = "",
       rows = [],
       rowsPerPage = 25,
@@ -278,7 +277,6 @@ class DatasetTable extends React.Component {
 DatasetTable.propTypes = {
   columnKeys: PropTypes.arrayOf(PropTypes.object),
   currentPage: PropTypes.number,
-  metadata: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.objectOf(PropTypes.object)]),
   queryYearColumn: PropTypes.string,
   rows: PropTypes.arrayOf(PropTypes.object),
   rowsPerPage: PropTypes.number,

--- a/src/components/partials/ExportDataModal.jsx
+++ b/src/components/partials/ExportDataModal.jsx
@@ -35,22 +35,10 @@ const formats = {
   },
 };
 
-const downloadMetadata = (database, metadata, title, table = "", description = "") => {
+const downloadMetadata = (metadata, title) => {
   const documentHeader = ["name", "alias", "details"];
-  let rows;
-  if (database === "towndata" || database === "gisdata") {
-    const metadataName = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => (attr.attrlabl ? attr.attrlabl : "undefined"));
-    const metadataAlias = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => attr.attalias);
-    const metadataDescription = metadata.documentation.metadata.eainfo.detailed.attr.map((attr) => (attr.attrdef ? attr.attrdef : "undefined"));
-    rows = [
-      ["title", "Title", title],
-      ["tbl_table", "Table", table],
-      ["descriptn", "Description", description],
-    ].concat(metadataName.map((item, i) => [item, metadataAlias[i], metadataDescription[i]]));
-  } else {
-    const values = metadata.map((row) => documentHeader.map((key) => row[key]));
-    rows = values.map((row) => row.reduce((a, b) => `${a},${b}`));
-  }
+  const values = metadata.map((row) => documentHeader.map((key) => row[key]));
+  const rows = values.map((row) => row.reduce((a, b) => `${a},${b}`));
   const csvHeader = "data:text/csv;charset=utf-8,";
   const documentRows = rows.reduce((a, b) => `${a}\n${b}`);
 
@@ -157,7 +145,6 @@ function ExportDataModal({
   datasetId,
   title = "",
   table = "",
-  description = "",
   database = "ds",
   schema = "",
   metadata = [],
@@ -296,7 +283,7 @@ function ExportDataModal({
 
   const handleDownloadSubmit = () => {
     if (exportTarget === "metadata") {
-      downloadMetadata(database, metadata, title, table, description);
+      downloadMetadata(metadata, title);
       return;
     }
 
@@ -530,7 +517,6 @@ ExportDataModal.propTypes = {
   datasetId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   title: PropTypes.string,
   table: PropTypes.string,
-  description: PropTypes.string,
   database: PropTypes.string,
   schema: PropTypes.string,
   metadata: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.objectOf(PropTypes.object)]),

--- a/src/components/partials/MetadataModal.jsx
+++ b/src/components/partials/MetadataModal.jsx
@@ -169,32 +169,10 @@ const MetadataModal = ({ show, handleClose, dataset }) => {
     
     try {
       const response = await axios.get(
-        `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}`
+        `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}&useNewMetadata=true`
       );
-      
-      // Handle gisdata differently - it has a different structure
-      if (dataset.db_name === 'gisdata' || dataset.db_name === 'towndata') {
-        // For gisdata, first get the metadata object from response
-        const metadata = Object.values(response.data)[0];
-        // Then navigate to documentation.metadata.eainfo.detailed.attr
-        const eainfo = metadata?.documentation?.metadata?.eainfo;
-        if (eainfo?.detailed?.attr && Array.isArray(eainfo.detailed.attr)) {
-          // Map attrlabl, attalias, attrdef to our format
-          const mappedMetadata = eainfo.detailed.attr.map(attr => ({
-            name: attr.attrlabl || 'N/A',
-            alias: attr.attalias || 'N/A',
-            details: attr.attrdef || 'N/A'
-          }));
-          setMetadata(mappedMetadata);
-        } else {
-          console.warn('gisdata metadata structure not found:', response.data);
-          setMetadata([]);
-        }
-      } else {
-        // Handle different metadata formats for other databases
-        const metadataData = Object.values(response.data)[0];
-        setMetadata(Array.isArray(metadataData) ? metadataData : []);
-      }
+      const metadataData = Object.values(response.data)[0];
+      setMetadata(Array.isArray(metadataData) ? metadataData : []);
     } catch (err) {
       console.error('Error fetching metadata:', err);
       setError('Failed to load metadata. Please try again later.');

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -208,7 +208,7 @@ class DataViewerClass extends React.Component {
     const tableQuery = axios.get(tableQueryUrl);
 
     const metadataQuery = axios.get(
-      `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}`,
+      `/api/metadata?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}&useNewMetadata=true`,
     );
 
     const queries = [tableQuery, metadataQuery];
@@ -219,25 +219,51 @@ class DataViewerClass extends React.Component {
       queries.push(yearQuery);
     }
 
-    if (dataset.schemaname === "tabular") {
-      axios
-        .all(queries)
-        .then((response) => {
-          const tableResults = response[0].data.rows;
-          const metadata = Object.values(response[1].data)[0];
-          const yearResults = queries.length === 3 ? response[2].data.rows : [];
+    // fetch and process the data.
+    axios
+      .all(queries)
+      .then((response) => {
+        const tableResults = response[0].data.rows;
+        const metadata = Object.values(response[1].data)[0];
+        const yearResults = queries.length === 3 ? response[2].data.rows : [];
 
-          // Validate metadata structure
-          const universeData = metadata.find((row) => row.name === "universe");
-          const descriptionData = metadata.find((row) => row.name === "descriptn");
-          const columnKeys = metadata
-            .filter((object) => tableResults[0] && Object.keys(tableResults[0]).includes(object.name))
-            .filter((header) => header.name !== "seq_id");
+        // Validate metadata structure
+        const universeData = metadata.find((row) => row.name === "universe");
+        const descriptionData = metadata.find((row) => row.name === "descriptn");
+        const columnKeys = metadata
+          .filter((object) => tableResults[0] && Object.keys(tableResults[0]).includes(object.name))
+          .filter((header) => header.name !== "seq_id") // never show seq_id even if it's in metadata
+          .filter((header) => header.name !== "shape"); // never show shape even if it's in metadata
 
-          // Initialize geography filter for municipal (_m) tables
-          let geographyColumn = null;
-          let availableGeographies = [];
-          if (dataset.table_name && dataset.table_name.endsWith("_m")) {
+        // Process the distinct year data
+        const distinctYears = yearResults.map((year) => Object.values(year)[0]).sort().reverse();
+
+        const visibleColumnKeys = this.getVisibleColumnKeys(columnKeys);
+        const marginColumnsByBase = this.getMarginColumnsByBase(columnKeys);
+        const selectedBaseColumns = visibleColumnKeys.map((col) => col.name);
+        let selectedColumns = this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase);
+        let selectedYears = distinctYears.length ? [distinctYears[0]] : [];
+
+        const parsedShare = parseDatasetViewShareSearch(this.props.location?.search ?? "");
+        if (parsedShare.baseColumnNames?.length) {
+          const visibleSet = new Set(visibleColumnKeys.map((c) => c.name));
+          const validBases = parsedShare.baseColumnNames.filter((n) => visibleSet.has(n));
+          if (validBases.length) {
+            selectedColumns = this.expandSelectedWithMargins(validBases, marginColumnsByBase);
+          }
+        }
+
+        const yearOverride = resolveYearsFromUrl(parsedShare, distinctYears);
+        if (yearOverride) selectedYears = yearOverride;
+
+        // Initialize geography filter for municipal (_m) tables in the tabular schema
+        let selectedGeographies;
+        let availableGeographies;
+        let geographyColumn;
+        if (dataset.schemaname === "tabular") {
+          geographyColumn = null;
+          availableGeographies = [];
+          if (dataset.table_name && dataset.table_name.endsWith("_m")) { // TODO: switch to using the geography column from data browser
             const candidateColumns = ["muni_name", "municipal", "muni"];
             geographyColumn = candidateColumns.find((col) => tableResults[0] && col in tableResults[0]) || null;
             if (geographyColumn) {
@@ -251,128 +277,39 @@ class DataViewerClass extends React.Component {
             }
           }
 
-          // Process the distinct year data
-          const distinctYears = yearResults.map((year) => Object.values(year)[0]).sort().reverse();
-
-          const visibleColumnKeys = this.getVisibleColumnKeys(columnKeys);
-          const marginColumnsByBase = this.getMarginColumnsByBase(columnKeys);
-          const selectedBaseColumns = visibleColumnKeys.map((col) => col.name);
-          let selectedColumns = this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase);
-          let selectedGeographies = availableGeographies;
-          let selectedYears = distinctYears.length ? [distinctYears[0]] : [];
-
-          const parsedShare = parseDatasetViewShareSearch(this.props.location?.search ?? "");
-          if (parsedShare.baseColumnNames?.length) {
-            const visibleSet = new Set(visibleColumnKeys.map((c) => c.name));
-            const validBases = parsedShare.baseColumnNames.filter((n) => visibleSet.has(n));
-            if (validBases.length) {
-              selectedColumns = this.expandSelectedWithMargins(validBases, marginColumnsByBase);
-            }
-          }
+          selectedGeographies = availableGeographies;
           const geoOverride = resolveGeographiesFromUrl(parsedShare, availableGeographies);
           if (geoOverride) selectedGeographies = geoOverride;
-          const yearOverride = resolveYearsFromUrl(parsedShare, distinctYears);
-          if (yearOverride) selectedYears = yearOverride;
+        }
 
-          this.setState({
-            availableYears: distinctYears,
-            rows: tableResults,
-            universe: universeData ? universeData.details : "",
-            description: descriptionData ? descriptionData.details : "",
-            columnKeys: columnKeys,
-            selectedColumns,
-            marginColumnsByBase,
-            metadata,
-            selectedYears,
-            table: dataset.table_name,
-            schema: dataset.schemaname,
-            database: dataset.db_name,
-            title: dataset.menu3,
-            source: dataset.source,
-            queryYearColumn: dataset.yearcolumn,
-            updatedAt: dataset.updated,
-            geographyColumn,
-            availableGeographies,
-            selectedGeographies,
-            linkInventoryRows: isDatasetInventoryCatalog(dataset),
-            loading: false,
-          });
-        })
-        .catch((error) => {
-          this.setState({ loading: false, error: "Please try again later" });
-          console.error("Error:", error);
+        this.setState({
+          availableYears: distinctYears,
+          rows: tableResults,
+          universe: universeData ? universeData.details : "",
+          description: descriptionData ? descriptionData.details : "",
+          columnKeys: columnKeys,
+          selectedColumns,
+          marginColumnsByBase,
+          metadata,
+          selectedYears,
+          table: dataset.table_name,
+          schema: dataset.schemaname,
+          database: dataset.db_name,
+          title: dataset.menu3,
+          source: dataset.source,
+          queryYearColumn: dataset.yearcolumn,
+          updatedAt: dataset.updated,
+          geographyColumn,
+          availableGeographies,
+          selectedGeographies,
+          linkInventoryRows: isDatasetInventoryCatalog(dataset),
+          loading: false,
         });
-    } else {
-      axios
-        .all(queries)
-        .then(async (response) => {
-          const tableResults = response[0].data.rows;
-          const metadata = Object.values(response[1].data)[0];
-          const yearResults = queries.length === 3 ? response[2].data.rows : [];
 
-          try {
-            // process the metadata
-            const columns = Object.keys(tableResults[0] || {});
-            const sortedMetadata = metadata.documentation.metadata.eainfo.detailed.attr
-              .map((attribute) => ({
-                name: attribute.attrlabl,
-                alias: attribute.attalias,
-              }))
-              .filter((header) => columns.includes(header.name))
-              .filter((header) => header.name !== "shape");
-
-            // Process the distinct year data
-            const distinctYears = yearResults.map((year) => Object.values(year)[0]).sort().reverse();
-
-            const visibleColumnKeys = this.getVisibleColumnKeys(sortedMetadata);
-            const marginColumnsByBase = this.getMarginColumnsByBase(sortedMetadata);
-            const selectedBaseColumns = visibleColumnKeys.map((col) => col.name);
-            let selectedColumns = this.expandSelectedWithMargins(selectedBaseColumns, marginColumnsByBase);
-            let selectedYears = distinctYears.length ? [distinctYears[0]] : [];
-
-            const parsedShare = parseDatasetViewShareSearch(this.props.location?.search ?? "");
-            if (parsedShare.baseColumnNames?.length) {
-              const visibleSet = new Set(visibleColumnKeys.map((c) => c.name));
-              const validBases = parsedShare.baseColumnNames.filter((n) => visibleSet.has(n));
-              if (validBases.length) {
-                selectedColumns = this.expandSelectedWithMargins(validBases, marginColumnsByBase);
-              }
-            }
-            const yearOverride = resolveYearsFromUrl(parsedShare, distinctYears);
-            if (yearOverride) selectedYears = yearOverride;
-
-            this.setState({
-              availableYears: distinctYears,
-              rows: tableResults,
-              description: metadata.documentation.metadata.dataIdInfo.idPurp || "",
-              columnKeys: sortedMetadata,
-              selectedColumns,
-              marginColumnsByBase,
-              metadata,
-              selectedYears,
-              table: dataset.table_name,
-              schema: dataset.schemaname,
-              database: dataset.db_name,
-              title: dataset.menu3,
-              source: dataset.source,
-              queryYearColumn: dataset.yearcolumn,
-              updatedAt: dataset.updated,
-              linkInventoryRows: isDatasetInventoryCatalog(dataset),
-              loading: false,
-            });
-          } catch (error) {
-            this.setState({
-              loading: false,
-              error: "Error parsing metadata",
-            });
-            console.error("Error parsing metadata:", error);
-          }
-        })
-        .catch((error) => {
-          this.setState({ loading: false, error: "Error fetching datasets" });
-          console.error("Error:", error);
-        });
-    }
+      }).catch((error) => {
+        this.setState({ loading: false, error: "Please try again later" });
+        console.error("Error:", error);
+      });
   }
 
   componentWillUnmount() {
@@ -493,7 +430,6 @@ class DataViewerClass extends React.Component {
             geographyColumn={this.state.geographyColumn}
             linkRowsToDatasetView={this.state.linkInventoryRows}
             updatePage={this.updatePage}
-            metadata={this.state.metadata}
           />
         </section>
       );


### PR DESCRIPTION
Now that all datasets have the same format of metadata, this PR cleans up all the code on the front end that was handling reading data in different formats based on the database. 

I'm also glad that the main "fetch data" function when viewing a dataset is no longer a large if/else block with a bunch of duplicated code. 