### PR TITLE
Muni finance gauge charts

### DIFF
--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -17,6 +17,7 @@ import ChartDetails from "./visualizations/ChartDetails";
 import PieChart from "../containers/visualizations/PieChart";
 import LineChart from "../containers/visualizations/LineChart";
 import GaugeChart from "../containers/visualizations/GaugeChart";
+import MultiGaugeChart from "../containers/visualizations/MultiGaugeChart";
 import TreeMap from "../containers/visualizations/TreeMap";
 import MunicipalFinanceOverridesMap from "./visualizations/MunicipalFinanceOverridesMap";
 import DownloadAllChartsButton from "./field/DownloadAllChartsButton";
@@ -451,24 +452,32 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
                 <h3>Municipal Finances</h3>
               </header>
               <div className="tab__row">
-                
-                  <ChartDetails
-                    chart={charts["municipal-finances"].fund_revenue}
-                    muni={muni}
-                    onViewData={handleShowModal}
-                    wrapperClassName="chart-wrapper--fund-revenue-breakdown"
-                  >
-                    <TreeMap chart={charts["municipal-finances"].fund_revenue} muni={muni} />
-                  </ChartDetails>
-             
+                <ChartDetails
+                  chart={charts["municipal-finances"].fund_revenue}
+                  muni={muni}
+                  onViewData={handleShowModal}
+                  wrapperClassName="chart-wrapper--fund-revenue-breakdown"
+                >
+                  <TreeMap chart={charts["municipal-finances"].fund_revenue} muni={muni} />
+                </ChartDetails>
+              </div>
+
+              <div className="tab__row">
+                <ChartDetails
+                  chart={charts["municipal-finances"].levy_share_gauge}
+                  muni={muni}
+                  onViewData={handleShowModal}
+                >
+                  <MultiGaugeChart chart={charts["municipal-finances"].levy_share_gauge} muni={muni} />
+                </ChartDetails>
               </div>
               
-                <div className="tab__row tab__row--full-width-map">
-                  <MunicipalFinanceOverridesMap
-                    config={charts["municipal-finances"].overrides_map_config}
-                    municipalFeature={municipalFeature}
-                  />
-                </div>
+              <div className="tab__row tab__row--full-width-map">
+                <MunicipalFinanceOverridesMap
+                  config={charts["municipal-finances"].overrides_map_config}
+                  municipalFeature={municipalFeature}
+                />
+              </div>
              
             </Tab>
           </div>

--- a/src/components/CommunityProfilesView.jsx
+++ b/src/components/CommunityProfilesView.jsx
@@ -468,11 +468,26 @@ const CommunityProfilesView = ({ name, municipalFeature, muniSlug }) => {
               </header>
               <div className="tab__row">
                 <ChartDetails
-                  chart={charts["municipal-finances"].levy_share_gauge}
+                  chart={charts["municipal-finance"].levy_share_gauge}
                   muni={muni}
                   onViewData={handleShowModal}
                 >
-                  <MultiGaugeChart chart={charts["municipal-finances"].levy_share_gauge} muni={muni} />
+                  <MultiGaugeChart chart={charts["municipal-finance"].levy_share_gauge} muni={muni} />
+                </ChartDetails>
+                {/* TODO: Add this back in once Zoe has updated the underlying data in the table. data has issues for now */}
+                {/* <ChartDetails
+                  chart={charts["municipal-finance"].levy_ceiling_gauge}
+                  muni={muni}
+                  onViewData={handleShowModal}
+                >
+                  <MultiGaugeChart chart={charts["municipal-finance"].levy_ceiling_gauge} muni={muni} />
+                </ChartDetails> */}
+                <ChartDetails
+                  chart={charts["municipal-finance"].levy_new_growth_gauge}
+                  muni={muni}
+                  onViewData={handleShowModal}
+                >
+                  <MultiGaugeChart chart={charts["municipal-finance"].levy_new_growth_gauge} muni={muni} />
                 </ChartDetails>
               </div>
               <div className="tab__row">

--- a/src/components/visualizations/MultiGaugeChart.jsx
+++ b/src/components/visualizations/MultiGaugeChart.jsx
@@ -112,7 +112,6 @@ const MultiGaugeChart = (props) => {
       const clampedPct = Math.max(minValue, Math.min(maxValue, value));
       const dashValue = (clampedPct / 100) * halfCirc;
       const dashGap = fullCirc - dashValue;
-
       const valueColor = colorRef.current(dataItem.label);
       chart
         .append("circle")
@@ -165,30 +164,30 @@ const MultiGaugeChart = (props) => {
       const percent = ((value - minValue) / (maxValue - minValue)) * 100;
       return { percent, label: dataItem.label };
     });
-    // const maxVal = Math.max(...percentages.map());
     const firstValue = percentagesByLabels[0];
     const displayLabel = `${firstValue.percent.toFixed(1)}%`;
     const valueText = chart
-    .append("text")
-    .attr("x", cx)
-    .attr("y", 31.5)
-    .attr("text-anchor", "middle")
-    .attr("class", "gauge-text")
-    .attr("font-size", "10")
-    .attr("font-weight", "400")
-    .attr("fill", "black")
-    .text(displayLabel);
-    const displaySubLabel = firstValue.label;
-    const labelText = chart
       .append("text")
       .attr("x", cx)
-      .attr("y", 36.5)
+      .attr("y", 35.5)
       .attr("text-anchor", "middle")
       .attr("class", "gauge-text")
-      .attr("font-size", "2.5")
+      .attr("font-size", "10")
       .attr("font-weight", "400")
       .attr("fill", "black")
-      .text(displaySubLabel);
+      .text(displayLabel);
+    // leaving out the sub-label for now
+    // const displaySubLabel = firstValue.label;
+    // const labelText = chart
+    //   .append("text")
+    //   .attr("x", cx)
+    //   .attr("y", 36.5)
+    //   .attr("text-anchor", "middle")
+    //   .attr("class", "gauge-text")
+    //   .attr("font-size", "2.4")
+    //   .attr("font-weight", "400")
+    //   .attr("fill", "black")
+    //   .text(displaySubLabel);
 
     // Add legend
     const legend = d3.select(legendContainerRef.current);

--- a/src/components/visualizations/MultiGaugeChart.jsx
+++ b/src/components/visualizations/MultiGaugeChart.jsx
@@ -1,0 +1,294 @@
+import React, { useRef, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import * as d3 from "d3";
+import MoonLoader from "react-spinners/MoonLoader";
+
+import colors from "../../constants/colors";
+import { chartSourceIsAcs } from "../../constants/charts";
+import { drawLegend, sortKeys } from "../../utils/charts";
+
+
+const primaryColors = Array.from(colors.CHART.PRIMARY.values());
+
+const container = {
+  width: 500,
+  height: 500,
+};
+
+const defaultMargin = {
+  top: 20,
+  left: 20,
+  right: 20,
+  bottom: -5, 
+};
+
+const MultiGaugeChart = (props) => {
+  const chartRef = useRef(null);
+  const svgRef = useRef(null);
+  const chartGroupRef = useRef(null);
+  const tooltipRef = useRef(null);
+
+  const legendContainerRef = useRef(null);
+  const colorRef = useRef(null);
+  
+
+  useEffect(() => {
+    // Create tooltip
+    tooltipRef.current = d3
+      .select("body")
+      .append("div")
+      .attr("class", "chart-tooltip")
+      .style("opacity", 0)
+      .style("position", "absolute")
+      .style("pointer-events", "none")
+      .style("background", "white")
+      .style("padding", "5px")
+      .style("border", "1px solid #ccc")
+      .style("border-radius", "3px")
+      .style("z-index", 1000);
+
+    // Create SVG with responsive sizing and fixed gauge viewBox (matches CodePen example)
+    svgRef.current = d3
+      .select(chartRef.current)
+      .append("svg")
+      .attr("width", "100%")
+      .attr("height", "100%")
+      .attr("preserveAspectRatio", "xMidYMid meet")
+      .attr("viewBox", "0 0 80 40");
+
+    // Create chart group
+    chartGroupRef.current = svgRef.current.append("g");
+
+    return () => {
+      if (tooltipRef.current) tooltipRef.current.remove();
+      if (svgRef.current) svgRef.current.remove();
+    };
+  }, []);
+
+  const renderChart = () => {
+    const chart = chartGroupRef.current;
+    const tooltip = tooltipRef.current;
+
+    // Process colors
+    const keys = props.legend.map(d => d.label);
+    const colors = props.legend.reduce((obj, d) => (d.color ? Object.assign(obj, { [d.label]: d.color }) : obj), {});
+    colorRef.current = d3
+      .scaleOrdinal()
+      .range(Object.keys(colors).length ? keys.map((key) => colors[key]) : keys.length > primaryColors.length ? extendedColors : primaryColors)
+      .domain(keys);
+
+    // Get the data (expects array of values that sum to 100)
+    const dataItems = props.data || [];
+
+    // Clear existing content
+    chart.selectAll("*").remove();
+    svgRef.current.selectAll(".axis-label").remove();
+
+    // Geometry matching the CodePen SVG
+    const cx = 40;
+    const cy = 40;
+    const radius = 31.8309886184;
+    const fullCirc = 2 * Math.PI * radius; // ≈ 200
+    const halfCirc = fullCirc / 2;
+    
+    // Background ring (full donut ring; only top half is visible due to viewBox)
+    const trackColor = props.backgroundColor || "#d2d3d4";
+    chart
+      .append("circle")
+      .attr("class", "donut-ring")
+      .attr("cx", cx)
+      .attr("cy", cy)
+      .attr("r", radius)
+      .attr("fill", "transparent")
+      .attr("stroke", trackColor)
+      .attr("stroke-width", 15);
+
+    // Value segments
+    let offset = 0;
+    const minValue = props.minValue || 0;
+    const maxValue = props.maxValue || 100;
+    dataItems.forEach((dataItem, idx) => {
+      const value = dataItem.value || 0;
+      const clampedPct = Math.max(minValue, Math.min(maxValue, value));
+      const dashValue = (clampedPct / 100) * halfCirc;
+      const dashGap = fullCirc - dashValue;
+
+      const valueColor = colorRef.current(dataItem.label);
+      chart
+        .append("circle")
+        .attr("class", "donut-segment")
+        .attr("cx", cx)
+        .attr("cy", cy)
+        .attr("r", radius)
+        .attr("fill", "transparent")
+        .attr("stroke", valueColor)
+        .attr("stroke-width", 15)
+        .attr("stroke-dasharray", `${dashValue} ${dashGap}`)
+        .attr("stroke-dashoffset", - halfCirc + offset)
+        .on("mouseover", (event) => {
+          const tooltipItems = dataItems.map(dataItem => {
+            const value = dataItem.value || 0;
+            const clampedPct = Math.max(minValue, Math.min(maxValue, value));
+            const labelColor = colorRef.current(dataItem.label);
+            const formattedPercentage = props.valueFormat ? `${props.valueFormat(clampedPct)}%` : `${clampedPct.toFixed(1)}%`;
+            const labelIcon = `<span style="color: ${labelColor};">●</span>`
+            return `<div>${labelIcon}${dataItem.label}: ${formattedPercentage}</div>`
+          });
+          tooltip
+            .style("opacity", 1)
+            .html(
+              `
+              <div style="padding: 4px;">
+                <div style="font-weight: bold;">${props.title || "Value"}</div>
+                ${tooltipItems.join('')}               
+              </div>
+            `,
+            )
+            .style("left", `${event.pageX + 10}px`)
+            .style("top", `${event.pageY - 10}px`);
+        })
+        .on("mousemove", (event) => {
+          tooltip
+            .style("left", `${event.pageX + 10}px`).style("top", `${event.pageY - 10}px`)
+        })
+        .on("mouseout", () => {
+          tooltip.style("opacity", 0);
+        });
+      
+      offset += dashGap;
+    });
+
+    // Center label
+    const percentagesByLabels = dataItems.map(dataItem => {
+      const value = dataItem.value || 0;
+      const mappedValue = Math.max(minValue, Math.min(maxValue, value));
+      const percent = ((value - minValue) / (maxValue - minValue)) * 100;
+      return { percent, label: dataItem.label };
+    });
+    // const maxVal = Math.max(...percentages.map());
+    const firstValue = percentagesByLabels[0];
+    const displayLabel = `${firstValue.percent.toFixed(1)}%`;
+    const valueText = chart
+    .append("text")
+    .attr("x", cx)
+    .attr("y", 31.5)
+    .attr("text-anchor", "middle")
+    .attr("class", "gauge-text")
+    .attr("font-size", "10")
+    .attr("font-weight", "400")
+    .attr("fill", "black")
+    .text(displayLabel);
+    const displaySubLabel = firstValue.label;
+    const labelText = chart
+      .append("text")
+      .attr("x", cx)
+      .attr("y", 36.5)
+      .attr("text-anchor", "middle")
+      .attr("class", "gauge-text")
+      .attr("font-size", "2.5")
+      .attr("font-weight", "400")
+      .attr("fill", "black")
+      .text(displaySubLabel);
+
+    // Add legend
+    const legend = d3.select(legendContainerRef.current);
+    legend.selectAll("*").remove();
+    drawLegend(legend, colorRef.current, keys);
+  };
+
+  const renderBlankChart = () => {
+    const chart = chartGroupRef.current;
+    if (!chart) return;
+    chart.selectAll("*").remove();
+
+    chart
+      .append("text")
+      .attr("class", "missing-data")
+      .attr("x", 40)
+      .attr("y", 20)
+      .attr("dy", "0.35em")
+      .attr("text-anchor", "middle")
+      .attr("font-size", "5")
+      .style("fill", "currentColor")
+      .text("Data not available.");
+  };
+
+  useEffect(() => {
+    if (!svgRef.current) return;
+
+    // While loading, clear any previous content so only the spinner is visible
+    if (props.isLoading && !props.hasData) {
+      const chart = chartGroupRef.current;
+      if (chart) {
+        chart.selectAll("*").remove();
+      }
+      return;
+    }
+
+    if (props.hasData) {
+      renderChart();
+    } else {
+      // Not loading and no data -> show "Data not available."
+      renderBlankChart();
+    }
+  }, [props.data, props.hasData, props.isLoading]);
+
+  return (
+    <div className="component chart GaugeChart">
+      <div
+        className="svg-wrapper"
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          width: '100%',
+          minHeight: props.hasData ? undefined : 120,
+        }}
+      >
+        {props.isLoading && !props.hasData && (
+          <div className="gauge-loader">
+            <MoonLoader size={24} color="#767676" />
+          </div>
+        )}
+        <div ref={chartRef} className="chart-container" style={{ width: '100%', maxWidth: `${props.width || container.width}px`, margin: '0 auto' }} />
+      </div>
+      <div ref={legendContainerRef} className="legend" />
+    </div>
+  );
+};
+
+MultiGaugeChart.propTypes = {
+  chart: PropTypes.object,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+  minValue: PropTypes.number,
+  maxValue: PropTypes.number,
+  valueColor: PropTypes.string,
+  backgroundColor: PropTypes.string,
+  // zones: PropTypes.arrayOf(
+  //   PropTypes.shape({
+  //     start: PropTypes.number.isRequired, // percentage start (0-100)
+  //     end: PropTypes.number.isRequired, // percentage end (0-100)
+  //     color: PropTypes.string,
+  //     opacity: PropTypes.number,
+  //   }),
+  // ),
+  showCenterCircle: PropTypes.bool,
+  showUnit: PropTypes.bool,
+  showLabels: PropTypes.bool,
+  unit: PropTypes.string,
+  minLabel: PropTypes.string,
+  maxLabel: PropTypes.string,
+  valueFormat: PropTypes.func,
+  title: PropTypes.string,
+  hasData: PropTypes.bool,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  isLoading: PropTypes.bool,
+  legend: PropTypes.array,
+};
+
+export default MultiGaugeChart;

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -1908,7 +1908,7 @@ export default {
             let mainDataApi = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=tabular&table=s2801_computer_internet_acs_m`;
             mainDataApi = `${mainDataApi}&columns=${columns.join(',')}`;
             mainDataApi = `${mainDataApi}&filters=acs_year:${year}`;
-            mainDataApi = `${mainDataApi}&orFilters=muni_id:${countyId},muni_id:353,municipal~${municipalityFormatted}%`;            
+            mainDataApi = `${mainDataApi}&orFilters=muni_id:${countyId},muni_id:353,municipal~${municipalityFormatted}%`;
             const response = await fetch(mainDataApi);
             if (!response.ok) {
               throw new Error(`HTTP error! status: ${response.status}`);
@@ -2308,8 +2308,6 @@ export default {
     },
   },
   "municipal-finances": {
-    
-    
     fund_revenue:{
       type: "tree-map",
       title: "Fund Revenue Breakdown",
@@ -2335,6 +2333,7 @@ export default {
               const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
               const muniName = String(municipality || "").replace(/'/g, "''");
               const selectList = columnList.join(",");
+              // TODO: this needs to be fixed, no SQL 
               const queryString = `
                 SELECT ${selectList}
                 FROM tabular.muni_finance_m
@@ -2384,7 +2383,97 @@ export default {
         label: "Fund Revenue",
         format: format.string.default,
       },
-    },overrides_map_config: {
+    },
+    levy_share_gauge: {
+      type: "gauge",
+      title: "Levy Share",
+      minValue: 0,
+      maxValue: 100,
+      // valueColor: "#44aa44",
+      backgroundColor: "#e0e0e0",
+      showUnit: true,
+      unit: "%",
+      showLabels: true,
+      valueFormat: (d) => d.toFixed(1),
+      width: 500,
+      height: 400,
+      tooltip: { type: "percentAndCount" },
+      tables: {
+        "tabular.muni_finance_m": (() => {
+          const columnList = ["muni_name", "fiscal_yr", "ro_lvypct", "cip_lvypct"];
+          return {
+            yearCol: "fiscal_yr",
+            latestYearOnly: true,
+            columns: columnList,
+            specialFetch: async (municipality, dispatchUpdate) => {
+              const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
+              const muniName = String(municipality || "").replace(/'/g, "''");
+              const selectList = columnList.join(",");
+
+              const years = await fetchYears('tabular', 'muni_finance_m', 'fiscal_yr', 1, 'DESC');
+              const year = years.length ? years[0] : 'unknown';
+
+              let mainDataApi = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=tabular&table=muni_finance_m`;
+              mainDataApi = `${mainDataApi}&columns=${selectList}`;
+              mainDataApi = `${mainDataApi}&filters=fiscal_yr:${year},muni_name~${muniName}%`;
+
+              const response = await fetch(mainDataApi);
+              if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+              }
+              const payload = (await response.json()) || {};
+              dispatchUpdate(payload.rows || []);
+            },
+          };
+        })(),
+      },
+      timeframe: async () => {
+        const years = await fetchYears("tabular", "muni_finance_m", "fiscal_yr", 1, "DESC");
+        return years && years[0] ? String(years[0]) : "";
+      },
+      transformer: (tables) => {
+        const data = tables["tabular.muni_finance_m"];
+        if (!data || data.length < 1) {
+          return [{ value: 0, marginOfError: null }]; // TODO: no moe?
+        }
+        const row = data[0];
+        const resAndOpenSpaceLevyPct =
+          row.ro_lvypct !== null && row.ro_lvypct !== undefined
+            ? parseFloat(row.ro_lvypct)
+            : 0;
+        const comercialResIndLevyPct =
+          row.cip_lvypct !== null && row.cip_lvypct !== undefined
+            ? parseFloat(row.cip_lvypct)
+            : 0;
+
+        const roValue = isNaN(resAndOpenSpaceLevyPct) ? 0 : Math.max(0, Math.min(100, resAndOpenSpaceLevyPct));
+        const criValue = isNaN(comercialResIndLevyPct) ? 0 : Math.max(0, Math.min(100, comercialResIndLevyPct));
+        
+        return [
+          { value: roValue, label: "Residential and Open Space Levy Percent" },
+          { value: criValue, label: "Commercial, Industrial, and Personal Levy Percent" },
+        ];
+      },
+      source:"MA Dept of Revenue",
+      datasetLinks: { "Dept of Revenue Municipal Finance": 502 },
+      xAxis: {
+        label: "Fund Revenue",
+        format: format.string.default,
+      },
+      legend: [
+        {
+          key: "ro_lvypct",
+          label: "Residential and Open Space Levy Percent",
+          color: colors.CHART.PRIMARY.get("DARK_GREEN"),
+        },
+        {
+          key: "cip_lvypct",
+          label: "Commercial, Industrial, and Personal Levy Percent",
+          color: colors.CHART.PRIMARY.get("TEAL_GREEN"),
+        },
+      ],
+    },
+    overrides_map_config: {
       mapTitleTemplate: "2024 Municipal Override Map",
       yearColumn: "fiscal_yr",
       tableSchema: "tabular",

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2389,7 +2389,6 @@ export default {
       title: "Levy Share",
       minValue: 0,
       maxValue: 100,
-      // valueColor: "#44aa44",
       backgroundColor: "#e0e0e0",
       showUnit: true,
       unit: "%",
@@ -2399,7 +2398,7 @@ export default {
       height: 400,
       tooltip: { type: "percentAndCount" },
       tables: {
-        "tabular.muni_finance_m": (() => {
+        "tabular.muni_finance_m_levy_share": (() => {
           const columnList = ["muni_name", "fiscal_yr", "ro_lvypct", "cip_lvypct"];
           return {
             yearCol: "fiscal_yr",
@@ -2432,7 +2431,7 @@ export default {
         return years && years[0] ? String(years[0]) : "";
       },
       transformer: (tables) => {
-        const data = tables["tabular.muni_finance_m"];
+        const data = tables["tabular.muni_finance_m_levy_share"];
         if (!data || data.length < 1) {
           return [{ value: 0, marginOfError: null }]; // TODO: no moe?
         }

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2655,7 +2655,7 @@ export default {
       transformer: (tables) => {
         const data = tables["tabular.muni_finance_m_levy_share"];
         if (!data || data.length < 1) {
-          return [{ value: 0, marginOfError: null }]; // TODO: no moe?
+          return [{ value: 0, }];
         }
         const row = data[0];
         const resAndOpenSpaceLevyPct =
@@ -2671,25 +2671,196 @@ export default {
         const criValue = isNaN(comercialResIndLevyPct) ? 0 : Math.max(0, Math.min(100, comercialResIndLevyPct));
         
         return [
-          { value: roValue, label: "Residential and Open Space Levy Percent" },
-          { value: criValue, label: "Commercial, Industrial, and Personal Levy Percent" },
+          { value: roValue, label: "Residential & Open Space Levy Percent" },
+          { value: criValue, label: "Commercial, Industrial, & Personal Levy Percent" },
         ];
       },
       source:"MA Dept of Revenue",
       datasetLinks: { "Dept of Revenue Municipal Finance": 502 },
-      xAxis: {
-        label: "Fund Revenue",
-        format: format.string.default,
-      },
       legend: [
         {
           key: "ro_lvypct",
-          label: "Residential and Open Space Levy Percent",
+          label: "Residential & Open Space Levy Percent",
           color: colors.CHART.PRIMARY.get("DARK_GREEN"),
         },
         {
           key: "cip_lvypct",
-          label: "Commercial, Industrial, and Personal Levy Percent",
+          label: "Commercial, Industrial, & Personal Levy Percent",
+          color: colors.CHART.PRIMARY.get("TEAL_GREEN"),
+        },
+      ],
+    },
+    levy_ceiling_gauge: {
+      type: "gauge",
+      title: "Levy Ceiling Share",
+      minValue: 0,
+      maxValue: 100,
+      backgroundColor: "#e0e0e0",
+      showUnit: true,
+      unit: "%",
+      showLabels: true,
+      valueFormat: (d) => d.toFixed(1),
+      width: 500,
+      height: 400,
+      tooltip: { type: "percentAndCount" },
+      tables: {
+        "tabular.muni_finance_m_levy_ceiling_share": (() => {
+          const columnList = ["muni_name", "fiscal_yr", "ro_pct", "cip_pct"];
+          return {
+            yearCol: "fiscal_yr",
+            latestYearOnly: true,
+            columns: columnList,
+            specialFetch: async (municipality, dispatchUpdate) => {
+              const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
+              const muniName = String(municipality || "").replace(/'/g, "''");
+              const selectList = columnList.join(",");
+
+              const years = await fetchYears('tabular', 'muni_finance_m', 'fiscal_yr', 1, 'DESC');
+              const year = years.length ? years[0] : 'unknown';
+
+              let mainDataApi = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=tabular&table=muni_finance_m`;
+              mainDataApi = `${mainDataApi}&columns=${selectList}`;
+              mainDataApi = `${mainDataApi}&filters=fiscal_yr:${year},muni_name~${muniName}%`;
+
+              const response = await fetch(mainDataApi);
+              if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+              }
+              const payload = (await response.json()) || {};
+              dispatchUpdate(payload.rows || []);
+            },
+          };
+        })(),
+      },
+      timeframe: async () => {
+        const years = await fetchYears("tabular", "muni_finance_m", "fiscal_yr", 1, "DESC");
+        return years && years[0] ? String(years[0]) : "";
+      },
+      transformer: (tables) => {
+        const data = tables["tabular.muni_finance_m_levy_ceiling_share"];
+        if (!data || data.length < 1) {
+          return [{ value: 0 }];
+        }
+        const row = data[0];
+        const resAndOpenSpaceLevyCeilingPct =
+          row.ro_pct !== null && row.ro_pct !== undefined
+            ? parseFloat(row.ro_pct)
+            : 0;
+        const comercialResIndLevyCeilingPct =
+          row.cip_pct !== null && row.cip_pct !== undefined
+            ? parseFloat(row.cip_pct)
+            : 0;
+
+        const roValue = isNaN(resAndOpenSpaceLevyCeilingPct) ? 0 : Math.max(0, Math.min(100, resAndOpenSpaceLevyCeilingPct));
+        const criValue = isNaN(comercialResIndLevyCeilingPct) ? 0 : Math.max(0, Math.min(100, comercialResIndLevyCeilingPct));
+        
+        return [
+          { value: roValue, label: "Residential & Open Space Levy Ceiling Percent" },
+          { value: criValue, label: "Commercial, Industrial, & Personal Levy Ceiling Percent" },
+        ];
+      },
+      source:"MA Dept of Revenue",
+      datasetLinks: { "Dept of Revenue Municipal Finance": 502 },
+      legend: [
+        {
+          key: "ro_pct",
+          label: "Residential & Open Space Levy Ceiling Percent",
+          color: colors.CHART.PRIMARY.get("DARK_GREEN"),
+        },
+        {
+          key: "cip_pct",
+          label: "Commercial, Industrial, & Personal Levy Ceiling Percent",
+          color: colors.CHART.PRIMARY.get("TEAL_GREEN"),
+        },
+      ],
+    },
+    levy_new_growth_gauge: {
+      type: "gauge",
+      title: "New Growth Not Applied to Limit",
+      minValue: 0,
+      maxValue: 100,
+      backgroundColor: "#e0e0e0",
+      showUnit: true,
+      unit: "%",
+      showLabels: true,
+      valueFormat: (d) => d.toFixed(1),
+      width: 500,
+      height: 400,
+      tooltip: { type: "percentAndCount" },
+      tables: {
+        "tabular.muni_finance_m_levy_new_growth": (() => {
+          const columnList = ["muni_name", "fiscal_yr", "res_ng_lvy", "cip_ng_lvy"];
+          return {
+            yearCol: "fiscal_yr",
+            latestYearOnly: true,
+            columns: columnList,
+            specialFetch: async (municipality, dispatchUpdate) => {
+              const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
+              const muniName = String(municipality || "").replace(/'/g, "''");
+              const selectList = columnList.join(",");
+
+              const years = await fetchYears('tabular', 'muni_finance_m', 'fiscal_yr', 1, 'DESC');
+              const year = years.length ? years[0] : 'unknown';
+
+              let mainDataApi = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&schema=tabular&table=muni_finance_m`;
+              mainDataApi = `${mainDataApi}&columns=${selectList}`;
+              mainDataApi = `${mainDataApi}&filters=fiscal_yr:${year},muni_name~${muniName}%`;
+
+              const response = await fetch(mainDataApi);
+              if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+              }
+              const payload = (await response.json()) || {};
+              dispatchUpdate(payload.rows || []);
+            },
+          };
+        })(),
+      },
+      timeframe: async () => {
+        const years = await fetchYears("tabular", "muni_finance_m", "fiscal_yr", 1, "DESC");
+        return years && years[0] ? String(years[0]) : "";
+      },
+      transformer: (tables) => {
+        const data = tables["tabular.muni_finance_m_levy_new_growth"];
+        if (!data || data.length < 1) {
+          return [{ value: 0 }];
+        }
+        const row = data[0];
+        const resNewGrowthForLevy =
+          row.res_ng_lvy !== null && row.res_ng_lvy !== undefined
+            ? parseFloat(row.res_ng_lvy)
+            : 0;
+        const cipNewGrowthForLevy =
+          row.cip_ng_lvy !== null && row.cip_ng_lvy !== undefined
+            ? parseFloat(row.cip_ng_lvy)
+            : 0;
+
+        // TODO: this sum to get the total is a temporary fix, eventually it should come from the table
+        const totalNewGrowth = resNewGrowthForLevy + cipNewGrowthForLevy;
+
+        // get the percentage of the total for both while preventing divide by 0
+        const resNewGrowthPercent = (resNewGrowthForLevy / (totalNewGrowth || 1)) * 100;
+        const cipNewGrowthPercent = (cipNewGrowthForLevy / (totalNewGrowth || 1)) * 100;
+
+        const roValue = isNaN(resNewGrowthPercent) ? 0 : Math.max(0, Math.min(100, resNewGrowthPercent));
+        const criValue = isNaN(cipNewGrowthPercent) ? 0 : Math.max(0, Math.min(100, cipNewGrowthPercent));
+        
+        return [
+          { value: roValue, label: "Residential New Growth Applied to Levy Limit" },
+          { value: criValue, label: "CIP New Growth Applied to Levy Limit" },
+        ];
+      },
+      source:"MA Dept of Revenue",
+      datasetLinks: { "Dept of Revenue Municipal Finance": 502 },
+      legend: [
+        {
+          key: "res_ng_lvy",
+          label: "Residential New Growth Applied to Levy Limit",
+          color: colors.CHART.PRIMARY.get("DARK_GREEN"),
+        },
+        {
+          key: "cip_ng_lvy",
+          label: "CIP New Growth Applied to Levy Limit",
           color: colors.CHART.PRIMARY.get("TEAL_GREEN"),
         },
       ],

--- a/src/containers/visualizations/MultiGaugeChart.js
+++ b/src/containers/visualizations/MultiGaugeChart.js
@@ -1,0 +1,118 @@
+import { connect } from 'react-redux';
+import MultiGaugeChart from '../../components/visualizations/MultiGaugeChart';
+import { selectChartLoading } from '../../reducers/chartSlice';
+
+function valuesHaveData(transformedData) {
+  const checkData = transformedData.reduce((acc, row) => {
+    let datumHasValue = false;
+    if (row.value !== null && row.value !== undefined && !isNaN(row.value)) {
+      datumHasValue = true;
+    }
+    acc.push(datumHasValue);
+    return acc;
+  }, []);
+
+  if (checkData.includes(true)) {
+    return true;
+  }
+  return false;
+}
+
+const mapStateToProps = (state, props) => {
+  const { muni, chart, isSubregion, isRPAregion } = props;
+  const isLoading = selectChartLoading(state);
+  const tables = Object.keys(chart.tables);
+
+  // Handle subregion data
+  if (isSubregion) {
+    if (tables.every((table) => state.subregion.cache[table] && state.subregion.cache[table][muni])) {
+      const subregionTables = tables.reduce((acc, table) => Object.assign(acc, { [table]: state.subregion.cache[table][muni] }), {});
+      return {
+        ...props,
+        data: chart.transformer(subregionTables, chart),
+        hasData: valuesHaveData(chart.transformer(subregionTables, chart)),
+        minValue: chart.minValue,
+        maxValue: chart.maxValue,
+        valueColor: chart.valueColor,
+        backgroundColor: chart.backgroundColor,
+        zones: chart.zones,
+        showCenterCircle: chart.showCenterCircle,
+        showUnit: chart.showUnit,
+        showLabels: chart.showLabels,
+        unit: chart.unit,
+        minLabel: chart.minLabel,
+        maxLabel: chart.maxLabel,
+        valueFormat: chart.valueFormat,
+        title: chart.title,
+        width: chart.width,
+        height: chart.height,
+        legend: chart.legend,
+        isLoading,
+      };
+    }
+  } else if (isRPAregion) {
+    if (tables.every((table) => state.rparegion.cache[table] && state.rparegion.cache[table][muni])) {
+      const rpaTables = tables.reduce((acc, table) => Object.assign(acc, { [table]: state.rparegion.cache[table][muni] }), {});
+      return {
+        ...props,
+        data: chart.transformer(rpaTables, chart),
+        hasData: valuesHaveData(chart.transformer(rpaTables, chart)),
+        minValue: chart.minValue,
+        maxValue: chart.maxValue,
+        valueColor: chart.valueColor,
+        backgroundColor: chart.backgroundColor,
+        zones: chart.zones,
+        showCenterCircle: chart.showCenterCircle,
+        showUnit: chart.showUnit,
+        showLabels: chart.showLabels,
+        unit: chart.unit,
+        minLabel: chart.minLabel,
+        maxLabel: chart.maxLabel,
+        valueFormat: chart.valueFormat,
+        title: chart.title,
+        width: chart.width,
+        height: chart.height,
+        legend: chart.legend,
+        isLoading,
+      };
+    }
+  } else if (tables.every((table) => state.chart.cache[table] && state.chart.cache[table][muni])) {
+    const muniTables = tables.reduce((acc, table) => Object.assign(acc, { [table]: state.chart.cache[table][muni] }), {});
+    return {
+      ...props,
+      data: chart.transformer(muniTables, chart),
+      hasData: valuesHaveData(chart.transformer(muniTables, chart)),
+      minValue: chart.minValue,
+      maxValue: chart.maxValue,
+      valueColor: chart.valueColor,
+      backgroundColor: chart.backgroundColor,
+      zones: chart.zones,
+      showCenterCircle: chart.showCenterCircle,
+      showUnit: chart.showUnit,
+      showLabels: chart.showLabels,
+      unit: chart.unit,
+      minLabel: chart.minLabel,
+      maxLabel: chart.maxLabel,
+      valueFormat: chart.valueFormat,
+      title: chart.title,
+      width: chart.width,
+      height: chart.height,
+      legend: chart.legend,
+      isLoading,
+    };
+  }
+
+  return {
+    ...props,
+    data: [],
+    hasData: false,
+    minValue: 0,
+    maxValue: 100,
+    isLoading,
+  };
+};
+
+const mapDispatchToProps = (dispatch, props) => ({});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MultiGaugeChart);
+export { valuesHaveData };


### PR DESCRIPTION
Adds two gauge charts to the muni-finance page. There is a third chart planned, but the underlying data for the third chart isn't ready to be used yet. 

<img width="1342" height="466" alt="Screenshot 2026-05-20 at 2 49 18 PM" src="https://github.com/user-attachments/assets/8fbae3a5-e6cc-497b-825c-ae31e0654483" />
