### PR TITLE
fix column drag for data inventory table and ui improvement

### DIFF
--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -1372,6 +1372,31 @@
         justify-content: center;
       }
 
+      .dataset-table__open-table-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.75rem;
+        height: 1.75rem;
+        padding: 0;
+        border: none;
+        border-radius: 4px;
+        background: transparent;
+        color: $color_brand-secondary;
+        cursor: pointer;
+        transition: background-color 0.15s ease, color 0.15s ease;
+
+        &:hover {
+          background: rgba($color_brand-secondary, 0.12);
+          color: $color_brand-secondary--dark;
+        }
+
+        &:focus-visible {
+          outline: 2px solid $color_brand-secondary;
+          outline-offset: 2px;
+        }
+      }
+
       .dataset-table__drag-grip {
         position: relative;
         display: inline-flex;
@@ -1508,51 +1533,35 @@
       }
     }
 
-    // Data browser inventory: each row opens that dataset in the data viewer
+    // Data browser inventory: row click or gutter icon opens dataset in a new tab
     .ui.table tbody tr.data-row--dataset-link {
       cursor: pointer;
       transition: background-color 0.15s ease, box-shadow 0.15s ease;
 
-      td {
+      td:not(.dataset-table__gutter) {
         color: $color_brand-secondary;
         text-decoration: underline;
         text-underline-offset: 2px;
       }
 
       &:hover {
-        background-color: rgba($color_brand-secondary, 0.18) !important;
-        box-shadow: inset 3px 0 0 $color_brand-secondary;
-
         td {
+          background-color: rgba($color_bg-medium, 0.22) !important;
+        }
+
+        td:not(.dataset-table__gutter) {
           color: $color_brand-secondary--dark;
         }
-      }
-
-      &:hover td:first-child::after,
-      &:focus-visible td:first-child::after {
-        opacity: 1;
-      }
-
-      td:first-child {
-        position: relative;
-        padding-right: 24px;
-      }
-
-      td:first-child::after {
-        content: "↗";
-        position: absolute;
-        right: 8px;
-        top: 50%;
-        transform: translateY(-50%);
-        font-size: 12px;
-        color: $color_brand-secondary;
-        opacity: 0.25;
-        transition: opacity 0.15s ease;
       }
 
       &:focus-visible {
         outline: 2px solid $color_brand-secondary;
         outline-offset: -2px;
+      }
+
+      .dataset-table__open-table-btn {
+        position: relative;
+        z-index: 1;
       }
     }
   }

--- a/src/components/partials/DataRow.jsx
+++ b/src/components/partials/DataRow.jsx
@@ -1,12 +1,14 @@
 import { useCallback } from "react";
 import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTable } from "@fortawesome/free-solid-svg-icons";
 import { getInventoryRowDatasetId } from "../../utils/datasetInventoryRow";
 
 const DataRow = ({
   headers,
   rowData,
   linkRowsToDatasetView,
-  showPreviewControls,
+  showRowDragControls,
   isDragging,
   onDragHandleDragStart,
   onDragHandleDragEnd,
@@ -15,6 +17,9 @@ const DataRow = ({
 }) => {
   const targetId = getInventoryRowDatasetId(rowData);
   const canLink = Boolean(linkRowsToDatasetView && targetId != null && targetId !== "");
+  const openDatasetTooltip = canLink ? "Open dataset table in a new tab" : "";
+  const showOpenTableAction = canLink;
+  const showGutter = showRowDragControls || showOpenTableAction;
 
   const go = useCallback(() => {
     if (!canLink) {
@@ -63,25 +68,41 @@ const DataRow = ({
         .join(" ")}
       onClick={canLink ? go : undefined}
       onKeyDown={canLink ? onKeyDown : undefined}
-      onDragOver={showPreviewControls ? onRowDragOver : undefined}
-      onDrop={showPreviewControls ? onRowDrop : undefined}
+      onDragOver={showRowDragControls ? onRowDragOver : undefined}
+      onDrop={showRowDragControls ? onRowDrop : undefined}
       tabIndex={canLink ? 0 : undefined}
       role={canLink ? "link" : undefined}
-      title={canLink ? "Click to view data (open in a new tab)" : undefined}
-      aria-label={canLink ? `Open dataset table view for id ${targetId} in a new tab` : undefined}
+      title={openDatasetTooltip}
+      aria-label={openDatasetTooltip}
     >
-      {showPreviewControls && (
+      {showGutter && (
         <td className="dataset-table__gutter">
           <div className="dataset-table__row-controls">
-            <span
-              className="dataset-table__drag-grip dataset-table__drag-grip--row"
-              draggable
-              onDragStart={onDragHandleDragStart}
-              onDragEnd={onDragHandleDragEnd}
-              onClick={(e) => e.stopPropagation()}
-              title="Drag to reorder row"
-              aria-label="Drag to reorder row"
-            />
+            {showRowDragControls && (
+              <span
+                className="dataset-table__drag-grip dataset-table__drag-grip--row"
+                draggable
+                onDragStart={onDragHandleDragStart}
+                onDragEnd={onDragHandleDragEnd}
+                onClick={(e) => e.stopPropagation()}
+                title="Drag to reorder row"
+                aria-label="Drag to reorder row"
+              />
+            )}
+            {showOpenTableAction && (
+              <button
+                type="button"
+                className="dataset-table__open-table-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  go();
+                }}
+                title={openDatasetTooltip}
+                aria-label={openDatasetTooltip}
+              >
+                <FontAwesomeIcon icon={faTable} size="sm" aria-hidden />
+              </button>
+            )}
           </div>
         </td>
       )}
@@ -94,7 +115,7 @@ DataRow.propTypes = {
   headers: PropTypes.arrayOf(PropTypes.string).isRequired,
   rowData: PropTypes.object.isRequired,
   linkRowsToDatasetView: PropTypes.bool,
-  showPreviewControls: PropTypes.bool,
+  showRowDragControls: PropTypes.bool,
   isDragging: PropTypes.bool,
   onDragHandleDragStart: PropTypes.func,
   onDragHandleDragEnd: PropTypes.func,
@@ -104,7 +125,7 @@ DataRow.propTypes = {
 
 DataRow.defaultProps = {
   linkRowsToDatasetView: false,
-  showPreviewControls: false,
+  showRowDragControls: false,
   isDragging: false,
 };
 

--- a/src/components/partials/DatasetTable.jsx
+++ b/src/components/partials/DatasetTable.jsx
@@ -295,6 +295,7 @@ class DatasetTable extends React.Component {
       updateSelectedColumns,
       previewColumnOrder = [],
       previewRowOrder = [],
+      onPreviewColumnOrderChange,
       onPreviewRowOrderChange,
       onResetPreviewLayout,
     } = this.props;
@@ -304,7 +305,10 @@ class DatasetTable extends React.Component {
 
     // Avoid a broken table (row drag gutter only) when all columns are deselected.
     if (columnKeys.length > 0 && orderedColumnKeys.length === 0) {
-      const showPreviewChrome = Boolean(updateSelectedColumns || onPreviewRowOrderChange);
+      const showRowPreviewControls = Boolean(updateSelectedColumns || onPreviewRowOrderChange);
+    const canCustomizeLayout = Boolean(
+        showRowPreviewControls || onPreviewColumnOrderChange,
+      );
       const defaultColumnNames = orderedColumnKeys.map((col) => col.name);
       const columnOrderCustom =
         previewColumnOrder.length > 0 && previewColumnOrder.join("|") !== defaultColumnNames.join("|");
@@ -314,7 +318,7 @@ class DatasetTable extends React.Component {
       return (
         <div className="table-wrapper">
           <DatasetTableContextMenu menu={contextMenu} onClose={this.closeContextMenu} />
-          {showPreviewChrome && hasPreviewCustomization && onResetPreviewLayout ? (
+          {canCustomizeLayout && hasPreviewCustomization && onResetPreviewLayout ? (
             <div className="dataset-table-preview-toolbar">
               <button type="button" className="dataset-table-preview-toolbar__reset" onClick={onResetPreviewLayout}>
                 Reset table layout
@@ -372,7 +376,13 @@ class DatasetTable extends React.Component {
     const effectiveSortDirection = sortColumn ? sortDirection : "asc";
     const sortedRows = this.sortData(allRows, effectiveSortColumn, effectiveSortDirection);
 
-    const showPreviewChrome = Boolean(updateSelectedColumns || onPreviewRowOrderChange);
+    const showRowDragControls = Boolean(
+      !linkRowsToDatasetView && (updateSelectedColumns || onPreviewRowOrderChange),
+    );
+    const showRowGutter = showRowDragControls || linkRowsToDatasetView;
+    const canCustomizeLayout = Boolean(
+      showRowDragControls || onPreviewColumnOrderChange,
+    );
 
     const previewRows = applyPreviewRowOrder(sortedRows, previewRowOrder);
     const rowKeysInView = previewRows.map((row, i) => getDatasetRowKey(row, i));
@@ -383,7 +393,7 @@ class DatasetTable extends React.Component {
         rowData={row}
         headers={orderedColumnKeys.map((key) => key.name)}
         linkRowsToDatasetView={linkRowsToDatasetView}
-        showPreviewControls={showPreviewChrome}
+        showRowDragControls={showRowDragControls}
         isDragging={dragRowIndex === i}
         onDragHandleDragStart={(e) => this.handleRowDragStart(e, i)}
         onDragHandleDragEnd={() => this.setState({ dragRowIndex: null })}
@@ -407,7 +417,7 @@ class DatasetTable extends React.Component {
     return (
       <div className="table-wrapper">
         <DatasetTableContextMenu menu={contextMenu} onClose={this.closeContextMenu} />
-        {showPreviewChrome && hasPreviewCustomization && onResetPreviewLayout ? (
+        {canCustomizeLayout && hasPreviewCustomization && onResetPreviewLayout ? (
           <div className="dataset-table-preview-toolbar">
             <button type="button" className="dataset-table-preview-toolbar__reset" onClick={onResetPreviewLayout}>
               Reset table layout
@@ -421,7 +431,12 @@ class DatasetTable extends React.Component {
                 <table className="ui sortable unstackable selectable compact table ember-view sticky-header-table dataset-table--preview">
                   <thead className="sticky-header">
                     <tr>
-                      {showPreviewChrome && <th className="dataset-table__gutter" aria-label="Row controls" />}
+                      {showRowGutter && (
+                        <th
+                          className="dataset-table__gutter"
+                          aria-label={linkRowsToDatasetView ? "Open dataset" : "Row controls"}
+                        />
+                      )}
                       {renderedHeaders}
                     </tr>
                   </thead>

--- a/src/components/visualizations/TreeMap.jsx
+++ b/src/components/visualizations/TreeMap.jsx
@@ -36,12 +36,12 @@ function partitionTreeData(data) {
   if (!Array.isArray(data)) return { tiles: [], summary: null };
   const normalized = data
     .map((d) => {
-      const rawValue = d.value ?? d.y;
+      const rawValue = d.value;
       const parsedValue = typeof rawValue === "number" ? rawValue : Number(rawValue);
       return {
-        key: d.key || d.id || d.label,
-        label: d.label || d.key || d.id || "Unknown",
-        group: d.group || "Value",
+        key: d.key,
+        label: d.label,
+        group: d.group,
         value: parsedValue,
         summaryOnly: Boolean(d.summaryOnly),
       };
@@ -80,6 +80,349 @@ function createColorHelpers(tileData, chart) {
   const getTextColor = () => "#ffffff";
 
   return { getFillColor, getTextColor };
+}
+
+/** Area ∝ value^exponent; 1 = true proportion, lower = more compression for readability. */
+export const TREEMAP_LAYOUT_VALUE_EXPONENT = 0.88;
+
+const TILE_LABEL_FONT = 13;
+const TILE_VALUE_FONT = 14;
+const TILE_EDGE_PADDING = 16;
+const TAX_LEVY_TILE_KEY = "tax_levy";
+/** Leave room for side tiles' labels; fund revenue only. */
+const DEFAULT_TAX_LEVY_MAX_LAYOUT_SHARE = 0.56;
+const TEXT_AWARE_SVG_HEIGHT = 400;
+
+/** Pixel size needed to render full category label + exact value at standard tile fonts. */
+export function measureTileTextMinimums(label, value, formatValue) {
+  const categoryLabel = String(label || "");
+  const valueText = formatTileValueLabel(value, formatValue);
+  let valueLines = [valueText];
+
+  const labelWidth = lineWidth(categoryLabel, TILE_LABEL_FONT);
+  let valueWidth = lineWidth(valueText, TILE_VALUE_FONT);
+  if (valueWidth > 320) {
+    valueLines = splitValueIntoLines(valueText);
+    valueWidth = Math.max(...valueLines.map((line) => lineWidth(line, TILE_VALUE_FONT)));
+  }
+
+  const minWidth = Math.ceil(Math.max(labelWidth, valueWidth, 72));
+  const labelBlock = Math.ceil(TILE_LABEL_FONT * 1.15); // 1.15 is the line height factor, so the lable won't be cut off
+  const valueBlock = valueLines.length * Math.ceil(TILE_VALUE_FONT * 1.2); // 1.2 is the line height factor 
+  const minHeight = Math.ceil(TILE_EDGE_PADDING + labelBlock + 6 + valueBlock + 8);
+
+  return { minWidth, minHeight, minArea: minWidth * minHeight, valueLines };
+}
+
+/**
+ * Fund revenue: smallest value sets the baseline; others scale by dollar ratio.
+ * Tax levy is capped so side tiles stay tall enough for full labels and amounts.
+ */
+export function computeTextAwareLayoutValues(tiles, formatValue, options = {}) {
+  if (!tiles?.length) return [];
+
+  const measured = tiles.map((tile) => ({
+    tile,
+    text: measureTileTextMinimums(tile.label, tile.value, formatValue),
+  }));
+
+  const smallestValueTile = measured.reduce(
+    (smallestSoFar, currentTile ) =>
+      currentTile.tile.value < smallestSoFar.tile.value ? currentTile : smallestSoFar,
+    measured[0],
+  );
+  const smallestValue = Math.max(smallestValueTile.tile.value, 0);
+  const smallestTextArea = smallestValueTile.text.minArea;
+
+  if (smallestValue === 0) {
+    return measured.map(({ tile, text }) => ({
+      ...tile,
+      layoutValue: text.minArea,
+      textMinWidth: text.minWidth,
+      textMinHeight: text.minHeight,
+      valueLines: text.valueLines,
+    }));
+  }
+
+  const taxLevyMaxShare = options.taxLevyMaxLayoutShare ?? DEFAULT_TAX_LEVY_MAX_LAYOUT_SHARE;
+
+  let layoutData = measured.map(({ tile, text }) => {
+    const proportionalWeight = (tile.value / smallestValue) * smallestTextArea;
+    const isSmallestValueTile = tile.value === smallestValueTile.tile.value;
+    const isTaxLevy = tile.key === TAX_LEVY_TILE_KEY;
+
+    let layoutValue = proportionalWeight;
+    if (isSmallestValueTile || !isTaxLevy) {
+      layoutValue = Math.max(proportionalWeight, text.minArea);
+    }
+
+    return {
+      ...tile,
+      layoutValue,
+      textMinWidth: text.minWidth,
+      textMinHeight: text.minHeight,
+      valueLines: text.valueLines,
+    };
+  });
+
+  const taxLevyTile = layoutData.find((tile) => tile.key === TAX_LEVY_TILE_KEY);
+  if (taxLevyTile && taxLevyMaxShare < 1) {
+    const totalLayoutWeight = layoutData.reduce((sum, tile) => sum + tile.layoutValue, 0);
+    const maxTaxLevyWeight = totalLayoutWeight * taxLevyMaxShare;
+    if (taxLevyTile.layoutValue > maxTaxLevyWeight) {
+      taxLevyTile.layoutValue = maxTaxLevyWeight;
+    }
+  }
+
+  if (options?.chartWidth > 0 && options?.chartHeight > 0) {
+    layoutData = refineLayoutValuesForText(layoutData, options.chartWidth, options.chartHeight);
+  }
+
+  return layoutData;
+}
+
+/**
+ * D3 only guarantees area, not width/height — a tile can be too skinny or too flat for its label.
+ * Lay out once, check each box, and nudge up anything that would clip text until everything fits.
+ */
+export function refineLayoutValuesForText(layoutData, chartWidth, chartHeight) {
+  const paddingInner = 4;
+  const paddingOuter = 2;
+  let next = layoutData.map((tile) => ({ ...tile }));
+
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const root = d3
+      .hierarchy({ children: next })
+      .sum((d) => d.layoutValue)
+      .sort((a, b) => b.value - a.value);
+    d3.treemap().size([chartWidth, chartHeight]).paddingInner(paddingInner).paddingOuter(paddingOuter)(root);
+
+    let changed = false;
+    const byKey = new Map(root.leaves().map((leaf) => [leaf.data.key, leaf]));
+
+    next = next.map((tile) => {
+      const leaf = byKey.get(tile.key);
+      if (!leaf) return tile;
+
+      const width = leaf.x1 - leaf.x0;
+      const height = leaf.y1 - leaf.y0;
+      if (width >= tile.textMinWidth && height >= tile.textMinHeight) return tile;
+
+      const scaleW = tile.textMinWidth / Math.max(width, 1);
+      const scaleH = tile.textMinHeight / Math.max(height, 1);
+      const scale = Math.max(scaleW, scaleH, 1.05);
+      changed = true;
+      return { ...tile, layoutValue: tile.layoutValue * scale * scale };
+    });
+
+    if (!changed) break;
+  }
+
+  return next;
+}
+
+/**
+ * Cap the largest tile's layout weight and redistribute so it renders shorter/wider.
+ * This is to avoid one huge category (e.g. tax levy) from swallowing the whole chart.
+ */
+export function capDominantTileLayoutValues(layoutValues, maxShare = 0.52) {
+  if (!layoutValues?.length || maxShare >= 1) return layoutValues;
+
+  const sum = layoutValues.reduce((acc, v) => acc + v, 0);
+  const maxVal = Math.max(...layoutValues);
+  const maxIdx = layoutValues.indexOf(maxVal);
+  const cap = sum * maxShare;
+  if (maxVal <= cap) return layoutValues;
+
+  const excess = maxVal - cap;
+  const othersSum = sum - maxVal;
+  const next = [...layoutValues];
+  next[maxIdx] = cap;
+  if (othersSum > 0) {
+    const boost = 1 + excess / othersSum;
+    for (let i = 0; i < next.length; i += 1) {
+      if (i !== maxIdx) next[i] *= boost;
+    }
+  }
+  return next;
+}
+
+/**
+ * Turn each category's dollar amount into a layout weight for D3 treemap.
+ * Fund revenue uses text-based sizing; other charts use the default path below.
+ */
+export function computeTreemapLayoutValues(tiles, options = {}) {
+  const useTextBasedSizing =
+    options.textAware && typeof options.formatValue === "function";
+
+  if (useTextBasedSizing) {
+    return computeTextAwareLayoutValues(tiles, options.formatValue, {
+      chartWidth: options.chartWidth,
+      chartHeight: options.chartHeight,
+    });
+  }
+
+  // Default treemap sizing 
+  // Slightly compress big vs small gaps so tiny categories still get a visible slice.
+  const valueCompressionExponent = options.exponent ?? TREEMAP_LAYOUT_VALUE_EXPONENT;
+  const smallestShareOfLargest = options.minShareOfMax ?? 0.022; // to avoid tiny categories being too small to see
+  const largestCategoryMaxShare = options.maxTileShare ?? 1; // to avoid one huge category (e.g. tax levy) from swallowing the whole chart.
+
+  const layoutWeightByTile = (tiles || []).map((tile) => {
+    const dollars = Math.max(tile.value, 0);
+    return Math.pow(dollars, valueCompressionExponent);
+  });
+
+  const largestLayoutWeight = Math.max(...layoutWeightByTile, 1);
+  const minimumLayoutWeight = largestLayoutWeight * smallestShareOfLargest;
+
+  let layoutWeights = layoutWeightByTile.map((weight) => Math.max(weight, minimumLayoutWeight));
+
+  // prevent one large category from taking up too much space 
+  layoutWeights = capDominantTileLayoutValues(layoutWeights, largestCategoryMaxShare);
+
+  return (tiles || []).map((tile, index) => ({
+    ...tile,
+    layoutValue: layoutWeights[index],
+  }));
+}
+
+function getTileSize(d) {
+  return { width: Math.max(0, d.x1 - d.x0), height: Math.max(0, d.y1 - d.y0) };
+}
+
+export function formatTileValueLabel(value, formatValue) {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "";
+  return formatValue(n);
+}
+
+const TEXT_PADDING = 14;
+const CHAR_WIDTH_RATIO = 0.43;
+
+/** Shrink font so full text fits on one line; never truncate or abbreviate. */
+export function fitFontSize(text, availableWidth, { base = 15, min = 8 } = {}) {
+  const widthAt = (fontSize) => String(text).length * CHAR_WIDTH_RATIO * fontSize + TEXT_PADDING;
+  if (availableWidth >= widthAt(base)) return base;
+  const scaled = Math.floor(base * (availableWidth / widthAt(base)));
+  return Math.max(min, scaled);
+}
+
+/** Break a long currency string across lines without dropping digits. */
+export function splitValueIntoLines(valueText) {
+  const text = String(valueText);
+  const lastComma = text.lastIndexOf(",");
+  if (lastComma > 0 && text.length - lastComma <= 5) {
+    return [text.slice(0, lastComma + 1), text.slice(lastComma + 1)];
+  }
+  return [text];
+}
+
+function lineWidth(text, fontSize) {
+  return String(text).length * CHAR_WIDTH_RATIO * fontSize + TEXT_PADDING;
+}
+
+function getValueDisplay(valueText, width, height, hasCategoryLabel) {
+  const availableHeight = hasCategoryLabel ? height - 36 : height - 16;
+  let fontSize = fitFontSize(valueText, width, { base: 15, min: 8 });
+  let lines = [valueText];
+
+  if (lineWidth(valueText, fontSize) > width) {
+    const split = splitValueIntoLines(valueText);
+    if (split.length > 1) {
+      lines = split;
+      const longest = lines.reduce((a, b) => (a.length >= b.length ? a : b));
+      fontSize = fitFontSize(longest, width, { base: 15, min: 8 });
+    } else {
+      fontSize = fitFontSize(valueText, width, { base: 15, min: 8 });
+    }
+  }
+
+  const lineHeight = Math.ceil(fontSize * 1.2);
+  const blockHeight = lineHeight * lines.length;
+  if (blockHeight > availableHeight && availableHeight > 0) {
+    fontSize = Math.max(8, Math.floor((fontSize * availableHeight) / blockHeight));
+  }
+
+  return { lines, fontSize, lineHeight };
+}
+
+/** Label + value layout for every tile; all strings stay complete (no … or compact $). */
+export function getTileTextLayout(d, formatValue) {
+  const { width, height } = getTileSize(d);
+  const categoryLabel = String(d.data.label || "");
+  const valueText = formatTileValueLabel(d.data.value, formatValue);
+  const labelY = 15;
+  const textMinWidth = d.data.textMinWidth;
+  const textMinHeight = d.data.textMinHeight;
+  const meetsTextMinimum =
+    textMinWidth != null && textMinHeight != null && width >= textMinWidth && height >= textMinHeight;
+
+  if (meetsTextMinimum) {
+    const valueLines = Array.isArray(d.data.valueLines) ? d.data.valueLines : [valueText];
+    const valueLineHeight = Math.ceil(TILE_VALUE_FONT * 1.2);
+    return {
+      showCategoryLabel: categoryLabel.length > 0,
+      categoryLabel,
+      categoryFontSize: `${TILE_LABEL_FONT}px`,
+      labelY,
+      valueLines,
+      valueStartY: labelY + Math.ceil(TILE_LABEL_FONT * 1.15) + 4,
+      valueFontSize: `${TILE_VALUE_FONT}px`,
+      valueLineHeight,
+    };
+  }
+
+  const showCategoryLabel = height >= 18 && width >= 16 && categoryLabel.length > 0;
+  const categoryFontSize = fitFontSize(categoryLabel, width, { base: TILE_LABEL_FONT, min: 9 });
+  const valueBlock = getValueDisplay(valueText, width, height, showCategoryLabel);
+  const valueStartY = showCategoryLabel
+    ? labelY + Math.ceil(categoryFontSize * 1.15) + 4
+    : Math.max(14, (height - valueBlock.lineHeight * valueBlock.lines.length) / 2 + valueBlock.fontSize);
+
+  return {
+    showCategoryLabel,
+    categoryLabel,
+    categoryFontSize: `${categoryFontSize}px`,
+    labelY,
+    valueLines: valueBlock.lines,
+    valueStartY,
+    valueFontSize: `${valueBlock.fontSize}px`,
+    valueLineHeight: valueBlock.lineHeight,
+  };
+}
+
+function appendTileText(group, layout, fill) {
+  if (layout.showCategoryLabel) {
+    group
+      .append("text")
+      .attr("class", "tile-label")
+      .attr("x", 8)
+      .attr("y", layout.labelY)
+      .style("font-size", layout.categoryFontSize)
+      .style("font-weight", 600)
+      .style("fill", fill)
+      .style("pointer-events", "none")
+      .text(layout.categoryLabel);
+  }
+
+  const valueText = group
+    .append("text")
+    .attr("class", "tile-value")
+    .attr("x", 8)
+    .attr("y", layout.valueStartY)
+    .style("font-size", layout.valueFontSize)
+    .style("font-weight", 500)
+    .style("fill", fill)
+    .style("pointer-events", "none");
+
+  layout.valueLines.forEach((line, index) => {
+    valueText
+      .append("tspan")
+      .attr("x", 8)
+      .attr("dy", index === 0 ? 0 : layout.valueLineHeight)
+      .text(line);
+  });
 }
 
 class TreeMap extends React.Component {
@@ -148,27 +491,42 @@ class TreeMap extends React.Component {
 
   renderChart() {
     const margin = defaultMargin;
-    const width = container.width - margin.left - margin.right;
-    const height = container.height - margin.top - margin.bottom;
+    const { chart } = this.props;
+    const textAware = Boolean(chart?.treemapTextAwareLayout);
+    const svgHeight = textAware ? TEXT_AWARE_SVG_HEIGHT : container.height;
+    const svgWidth = container.width;
+    const width = svgWidth - margin.left - margin.right;
+    const height = svgHeight - margin.top - margin.bottom;
     const { tiles } = partitionTreeData(this.props.data);
 
+    this.chart
+      .attr("viewBox", `0 0 ${svgWidth} ${svgHeight}`)
+      .attr("width", svgWidth)
+      .attr("height", svgHeight);
+
     if (!this.props.hasData || tiles.length === 0) {
-      this.renderBlankChart(container.width, container.height);
+      this.renderBlankChart(svgWidth, svgHeight);
       return;
     }
 
-    // Visual-only sizing tweaks for readability balance:
-    // compress big-value dominance so smaller categories remain visible in print and screen.
-    const layoutData = tiles.map((d) => ({
-      ...d,
-      layoutValue: (() => {
-        const label = String(d.label || "");
-        const compressed = Math.pow(Math.max(d.value, 0), 0.65);
-        // Keep categories visible even when values are small or zero.
-        const boosted = /all other/i.test(label) ? compressed * 1.35 : compressed;
-        return Math.max(boosted, 10);
-      })(),
-    }));
+    const formatValue = this.resolveValueFormatter();
+    const layoutExponent =
+      chart && Number.isFinite(chart.treemapLayoutExponent) ? chart.treemapLayoutExponent : undefined;
+    const maxTileShare =
+      chart && Number.isFinite(chart.treemapMaxTileShare) ? chart.treemapMaxTileShare : undefined;
+    const taxLevyMaxLayoutShare =
+      chart && Number.isFinite(chart.treemapTaxLevyMaxLayoutShare)
+        ? chart.treemapTaxLevyMaxLayoutShare
+        : undefined;
+    const layoutData = computeTreemapLayoutValues(tiles, {
+      exponent: layoutExponent,
+      maxTileShare: textAware ? 1 : maxTileShare,
+      textAware,
+      formatValue,
+      chartWidth: width,
+      chartHeight: height,
+      taxLevyMaxLayoutShare,
+    });
 
     const root = d3
       .hierarchy({ children: layoutData })
@@ -178,8 +536,6 @@ class TreeMap extends React.Component {
     d3.treemap().size([width, height]).paddingInner(4).paddingOuter(2)(root);
 
     const { getFillColor, getTextColor } = createColorHelpers(tiles);
-
-    const formatValue = this.resolveValueFormatter();
 
     this.chart.selectAll("*").remove();
     const g = this.chart.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
@@ -209,36 +565,18 @@ class TreeMap extends React.Component {
         this.tooltip.style("opacity", 0);
       });
 
-    leaves
-      .filter((d) => d.x1 - d.x0 >= 28 && d.y1 - d.y0 >= 18)
-      .append("text")
-      .attr("x", 8)
-      .attr("y", 18)
-      .style("font-size", "13px")
-      .style("font-weight", 600)
-      .style("fill", (d) => getTextColor(d.data))
-      .style("pointer-events", "none")
-      .text((d) => {
-        const maxChars = Math.max(3, Math.floor((d.x1 - d.x0 - 14) / 7));
-        return d.data.label.length > maxChars ? `${d.data.label.slice(0, maxChars - 1)}…` : d.data.label;
-      });
-
-    leaves
-      .filter((d) => d.x1 - d.x0 >= 88 && d.y1 - d.y0 >= 50)
-      .append("text")
-      .attr("x", 8)
-      .attr("y", 42)
-      .style("font-size", "15px")
-      .style("font-weight", 500)
-      .style("fill", (d) => getTextColor(d.data))
-      .style("pointer-events", "none")
-      .text((d) => formatValue(d.data.value));
+    leaves.each(function (d) {
+      appendTileText(d3.select(this), getTileTextLayout(d, formatValue), getTextColor(d.data));
+    });
   }
 
   render() {
     const { tiles, summary } = partitionTreeData(this.props.data);
     const { getFillColor } = createColorHelpers(tiles, this.props.chart);
     const formatBig = this.resolveValueFormatter();
+    const svgDisplayHeight = this.props.chart?.treemapTextAwareLayout
+      ? `${TEXT_AWARE_SVG_HEIGHT}px`
+      : "320px";
     return (
       <div className="component chart TreeMap">
         <div
@@ -307,7 +645,10 @@ class TreeMap extends React.Component {
               alignItems: "stretch",
             }}
           >
-            <svg ref={this.chartRef} style={{ display: "block", width: "100%", maxWidth: "100%", height: "320px" }} />
+            <svg
+              ref={this.chartRef}
+              style={{ display: "block", width: "100%", maxWidth: "100%", height: svgDisplayHeight }}
+            />
           </div>
         </div>
         {tiles.length > 0 ? (

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2540,6 +2540,8 @@ export default {
     fund_revenue: {
       type: "tree-map",
       title: "Fund Revenue Breakdown",
+      // Size tiles from smallest category's text needs, then scale others by data value.
+      treemapTextAwareLayout: true,
       colors: Array.from(colors.CHART.PRIMARY.values()).slice(-4),
       valueFormatter: (v) => {
         const n = typeof v === "number" ? v : Number(v);

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -483,18 +483,14 @@ class DataViewerClass extends React.Component {
             geographyColumn={this.state.geographyColumn}
             linkRowsToDatasetView={this.state.linkInventoryRows}
             updatePage={this.updatePage}
-            updateSelectedColumns={
-              this.state.linkInventoryRows ? undefined : this.updateSelectedColumns
-            }
+            updateSelectedColumns={this.updateSelectedColumns}
             previewColumnOrder={this.state.previewColumnOrder}
             previewRowOrder={this.state.previewRowOrder}
-            onPreviewColumnOrderChange={
-              this.state.linkInventoryRows ? undefined : this.onPreviewColumnOrderChange
-            }
+            onPreviewColumnOrderChange={this.onPreviewColumnOrderChange}
             onPreviewRowOrderChange={
               this.state.linkInventoryRows ? undefined : this.onPreviewRowOrderChange
             }
-            onResetPreviewLayout={this.state.linkInventoryRows ? undefined : this.onResetPreviewLayout}
+            onResetPreviewLayout={this.onResetPreviewLayout}
           />
         </section>
       );


### PR DESCRIPTION
<img width="1451" height="658" alt="Screenshot 2026-05-21 at 3 11 12 PM" src="https://github.com/user-attachments/assets/4b9b4cdc-bb59-469b-af24-38d087e18f85" />

- reconnected the table’s input props so column reorder callbacks reach dataset table on the inventory page. dragging a column header now updates the column order 

-  removed the  arrow on the first cell. added a table icon in the left gutter so there’s an obvious control to open a dataset and the icon won't be affected if a user hides a specific column. 

- remove the arrow icon, and add gutter icon instead to make it more user friendly 