### PR TITLE
Removes last references to deprecated query param

### DIFF
--- a/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
+++ b/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
@@ -44,6 +44,7 @@ function metadataResponseToRowArray(container) {
   const rows = Object.values(container).find((v) => Array.isArray(v));
   if (rows) return rows;
 
+  // TODO: This is the old metadata format. gisdata tables now return metadata in the same format as tabular tables
   const gis = container.documentation?.metadata?.eainfo?.detailed?.attr;
   return Array.isArray(gis) ? gis : [];
 }

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2629,7 +2629,6 @@ export default {
             latestYearOnly: true,
             columns: columnList,
             specialFetch: async (municipality, dispatchUpdate) => {
-              const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
               const muniName = String(municipality || "").replace(/'/g, "''");
               const selectList = columnList.join(",");
 
@@ -2713,7 +2712,6 @@ export default {
             latestYearOnly: true,
             columns: columnList,
             specialFetch: async (municipality, dispatchUpdate) => {
-              const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
               const muniName = String(municipality || "").replace(/'/g, "''");
               const selectList = columnList.join(",");
 
@@ -2797,7 +2795,6 @@ export default {
             latestYearOnly: true,
             columns: columnList,
             specialFetch: async (municipality, dispatchUpdate) => {
-              const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
               const muniName = String(municipality || "").replace(/'/g, "''");
               const selectList = columnList.join(",");
 
@@ -2881,7 +2878,6 @@ export default {
           },
           specialFetch: async (municipality, dispatchUpdate) => {
             const columnList = ["muni_name", "fiscal_yr", "win_amt", "loss_amt"];
-            const api = `${locations.BROWSER_API}?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=ds&query=`;
             const muniName = String(municipality || "").replace(/'/g, "''");
             const selectList = columnList.join(",");
 


### PR DESCRIPTION
Removes a few unused references to the `query` query parameter. 

Also adds a TODO for a place where the old metadata format is still being used. That will need to be updated 