### PR TITLE
Rows per page defaults to 10

### DIFF
--- a/src/components/partials/DatasetTable.jsx
+++ b/src/components/partials/DatasetTable.jsx
@@ -285,7 +285,7 @@ class DatasetTable extends React.Component {
       currentPage = 1,
       queryYearColumn = "",
       rows = [],
-      rowsPerPage = 25,
+      rowsPerPage = 10,
       selectedColumns = [],
       selectedYears = [],
       selectedGeographies = [],

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -27,7 +27,7 @@ class DataViewerClass extends React.Component {
     this.state = {
       currentPage: 1,
       loading: true,
-      rowsPerPage: 25,
+      rowsPerPage: 10,
       selectedColumns: [], // Will be initialized with all columns
       marginColumnsByBase: {},
       availableGeographies: [],


### PR DESCRIPTION
This is mostly to prevent issues where the user can scroll horizontally and also see the column headers at the same time. 