### PR TITLE
Fixes search highlight bug

### DIFF
--- a/src/utils/manageDatasets.js
+++ b/src/utils/manageDatasets.js
@@ -95,6 +95,40 @@ export function filterDatasets({
   return filtered;
 }
 
+// Helper function for highlightDatasets, helps handle search highlights that overlap (e.g. munici & nicipal)
+function generateNewHighlight(existingHighlight, newHighlight) {
+  // no existing highlights
+  if (!existingHighlight) return newHighlight;
+
+  let updatedHighlight;
+  existingHighlight.indices.forEach(existingHL => {
+    if (updatedHighlight !== undefined) return; // break if set
+
+    // fully contained in existing highlight
+    if (newHighlight[0] >= existingHL[0] && newHighlight[1] <= existingHL[1]) {
+      updatedHighlight = null;
+      return;
+    }
+
+    // starts inside existing highlight:
+    if (newHighlight[0] >= existingHL[0] && newHighlight[0] <= existingHL[1]) {
+      updatedHighlight = [existingHL[1] + 1, newHighlight[1]];
+      return;
+    }
+
+    // ends inside existing highlight:
+    if (newHighlight[1] >= existingHL[0] && newHighlight[1] <= existingHL[1]) {
+      updatedHighlight = [newHighlight[0], existingHL[0] - 1];
+      return;
+    }
+  });
+
+  if (updatedHighlight === undefined) {
+    return newHighlight;
+  } else {
+    return updatedHighlight;
+  }
+}
 
 /**
  * Creates and returns an object containing a mapping of dataset ids to the highlighted text in each dataset. 
@@ -138,11 +172,18 @@ export function highlightDatasets({ datasets = [], searchQuery = '' }) {
           searchTokens.forEach(searchTerm => {
             const highlightRegex = new RegExp(searchTerm, 'gi');
             tableName.replace(highlightRegex, (matched, offset) => {
-              const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'table_name' && hl.indices.find(i => i[0] == offset));
-              if (!alreadyMatched) {
+              const newHighlightIdxs = [offset, offset + matched.length - 1];
+              const existingHighlights = highlights[datasetId].find(hl => hl.key === 'table_name');
+
+              const trimmedNewHighlightIdxs = generateNewHighlight(existingHighlights, newHighlightIdxs);
+              if (!trimmedNewHighlightIdxs) return; // fully overlapped, no changes
+
+              if (existingHighlights) {
+                existingHighlights.indices.push(trimmedNewHighlightIdxs);
+              } else {
                 highlights[datasetId].push({
                   key: 'table_name',
-                  indices: [[offset, offset + matched.length - 1]]
+                  indices: [newHighlightIdxs]
                 });
               }
             });
@@ -153,11 +194,18 @@ export function highlightDatasets({ datasets = [], searchQuery = '' }) {
           searchTokens.forEach(searchTerm => {
             const highlightRegex = new RegExp(searchTerm, 'gi');
             datasetName.replace(highlightRegex, (matched, offset) => {
-              const alreadyMatched = highlights[datasetId].find(hl => hl.key == 'menu3' && hl.indices.find(i => i[0] == offset));
-              if (!alreadyMatched) {
+              const newHighlightIdxs = [offset, offset + matched.length - 1];
+              const existingHighlights = highlights[datasetId].find(hl => hl.key === 'menu3');
+
+              const trimmedNewHighlightIdxs = generateNewHighlight(existingHighlights, newHighlightIdxs);
+              if (!trimmedNewHighlightIdxs) return; // fully overlapped, no changes
+
+              if (existingHighlights) {
+                existingHighlights.indices.push(trimmedNewHighlightIdxs);
+              } else {
                 highlights[datasetId].push({
                   key: 'menu3',
-                  indices: [[offset, offset + matched.length - 1]]
+                  indices: [newHighlightIdxs]
                 });
               }
             });


### PR DESCRIPTION
I noticed a bug where partially overlapping search terms were displaying incorrectly when highlighting in the search results. I've attached a before and after picture to show the issue and the fix. 

Before:
<img width="1377" height="455" alt="Screenshot 2026-06-03 at 10 29 17 AM" src="https://github.com/user-attachments/assets/64ebfe28-8b65-4dda-850b-44e243dad368" />


After:
<img width="1401" height="411" alt="Screenshot 2026-06-03 at 10 29 48 AM" src="https://github.com/user-attachments/assets/d90cf9bd-5791-4639-8829-6b07821a4922" />
