### PR TITLE
Indicate hidden columns

### DIFF
--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -1546,6 +1546,87 @@
       .dataset-table__row--dragging {
         opacity: 0.55;
       }
+
+      .dataset-table__hidden-columns-marker {
+        width: 8px;
+        min-width: 8px;
+        max-width: 10px;
+        padding: 0 !important;
+        vertical-align: middle;
+        text-align: center;
+        background: transparent !important;
+        border-left: none !important;
+        border-right: none !important;
+        cursor: pointer;
+        position: relative;
+
+        &__line {
+          display: block;
+          width: 3px;
+          height: 100%;
+          min-height: 2.25rem;
+          margin: 0 auto;
+          background: #217346;
+          border-radius: 2px;
+          transition: width 0.12s ease, background-color 0.12s ease;
+        }
+
+        &:hover &__line,
+        &:focus-visible &__line {
+          width: 4px;
+          background: #1a5c38;
+        }
+
+        &:hover,
+        &:focus-visible {
+          cursor: pointer;
+        }
+
+        &:focus-visible {
+          outline: 2px solid $color_brand-secondary;
+          outline-offset: -1px;
+        }
+
+        &[data-hidden-count]::after {
+          content: attr(data-hidden-count);
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          font-size: 0.625rem;
+          font-weight: 700;
+          line-height: 1;
+          color: #fff;
+          background: #217346;
+          border-radius: 999px;
+          min-width: 1rem;
+          height: 1rem;
+          padding: 0 0.2rem;
+          display: none;
+          align-items: center;
+          justify-content: center;
+          pointer-events: none;
+        }
+
+        &:hover[data-hidden-count]::after,
+        &:focus-visible[data-hidden-count]::after {
+          display: inline-flex;
+        }
+
+        &--body {
+          cursor: default;
+          pointer-events: none;
+
+          .dataset-table__hidden-columns-marker__line {
+            min-height: 1.5rem;
+            opacity: 0.85;
+          }
+        }
+      }
+
+      thead .dataset-table__hidden-columns-marker {
+        z-index: 2;
+      }
     }
 
     // Data browser inventory: row click or gutter icon opens dataset in a new tab
@@ -1553,7 +1634,7 @@
       cursor: pointer;
       transition: background-color 0.15s ease, box-shadow 0.15s ease;
 
-      td:not(.dataset-table__gutter) {
+      td:not(.dataset-table__gutter):not(.dataset-table__hidden-columns-marker--body) {
         color: $color_brand-secondary;
         text-decoration: underline;
         text-underline-offset: 2px;
@@ -1564,7 +1645,7 @@
           background-color: rgba($color_bg-medium, 0.22) !important;
         }
 
-        td:not(.dataset-table__gutter) {
+        td:not(.dataset-table__gutter):not(.dataset-table__hidden-columns-marker--body) {
           color: $color_brand-secondary--dark;
         }
       }

--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -1185,7 +1185,7 @@
   .dataset-table-context-menu {
     position: fixed;
     z-index: 9999;
-    min-width: 10rem;
+    min-width: 14rem;
     padding: 0.25rem 0;
     background: #fff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1193,7 +1193,9 @@
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 
     &__item {
-      display: block;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
       width: 100%;
       padding: 0.5rem 0.85rem;
       border: none;
@@ -1202,9 +1204,29 @@
       font-size: 0.875rem;
       cursor: pointer;
 
-      &:hover {
+      &:hover,
+      &:focus-visible {
+        cursor: pointer;
         background: $color_bg-light;
       }
+    }
+
+    &__icon {
+      display: inline-flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
+      width: 1rem;
+      color: $color_font-medium;
+      cursor: pointer;
+      pointer-events: none;
+    }
+
+    &__label {
+      flex: 1;
+      min-width: 0;
+      cursor: pointer;
+      pointer-events: none;
     }
   }
 
@@ -1473,57 +1495,50 @@
         gap: 0.2rem;
       }
 
-      .sort-icon-wrap {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 1.35rem;
-        height: 1.35rem;
-        margin-left: 0;
-      }
-
-      .sort-icon {
-        font-size: 0.8125rem;
-        line-height: 1;
-        color: $color_font-medium;
-        vertical-align: middle;
-
-        svg {
-          display: block;
-        }
-
-        &--inactive {
-          opacity: 0.45;
-        }
-
-        &--active {
-          opacity: 0.9;
-        }
-      }
-
-      .dataset-table__hide-btn {
+      .dataset-table__header-menu-btn {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
         border: none;
+        border-radius: 4px;
         background: transparent;
         color: $color_font-medium;
-        font-size: 1rem;
-        line-height: 1;
         width: 1.35rem;
         height: 1.35rem;
         padding: 0;
         cursor: pointer;
-        opacity: 0;
-        transition: opacity 0.15s ease;
+        opacity: 0.55;
+        transition: opacity 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+
+        &:hover,
+        &:focus-visible {
+          cursor: pointer;
+        }
 
         &:hover {
+          opacity: 1;
+          background: rgba($color_brand-secondary, 0.1);
+          color: $color_brand-secondary--dark;
+        }
+
+        &:focus-visible {
+          outline: 2px solid $color_brand-secondary;
+          outline-offset: 1px;
+          opacity: 1;
+        }
+
+        svg {
+          pointer-events: none;
+        }
+
+        &--sorted {
+          opacity: 0.9;
           color: $color_brand-secondary--dark;
         }
       }
 
-      th:hover .dataset-table__hide-btn {
+      th:hover .dataset-table__header-menu-btn {
         opacity: 0.9;
       }
 

--- a/src/components/partials/DataRow.jsx
+++ b/src/components/partials/DataRow.jsx
@@ -5,7 +5,8 @@ import { faTable } from "@fortawesome/free-solid-svg-icons";
 import { getInventoryRowDatasetId } from "../../utils/datasetInventoryRow";
 
 const DataRow = ({
-  headers,
+  columnSegments,
+  showHiddenColumnMarkers,
   rowData,
   linkRowsToDatasetView,
   showRowDragControls,
@@ -54,9 +55,23 @@ const DataRow = ({
     return value;
   };
 
-  const renderedRow = headers
-    .filter((header) => header !== "seq_id")
-    .map((header) => <td key={header}>{formatValue(rowData[header])}</td>);
+  const renderedRow = columnSegments.flatMap((segment, segmentIndex) => {
+    if (segment.type === "hidden") {
+      if (!showHiddenColumnMarkers) return [];
+      return [
+        <td
+          key={`hidden-${segmentIndex}-${segment.columnNames.join("|")}`}
+          className="dataset-table__hidden-columns-marker dataset-table__hidden-columns-marker--body"
+          aria-hidden
+        />,
+      ];
+    }
+
+    const { column } = segment;
+    if (column.name === "seq_id") return [];
+
+    return [<td key={column.name}>{formatValue(rowData[column.name])}</td>];
+  });
 
   return (
     <tr
@@ -112,7 +127,14 @@ const DataRow = ({
 };
 
 DataRow.propTypes = {
-  headers: PropTypes.arrayOf(PropTypes.string).isRequired,
+  columnSegments: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.oneOf(["visible", "hidden"]).isRequired,
+      column: PropTypes.object,
+      columnNames: PropTypes.arrayOf(PropTypes.string),
+    }),
+  ).isRequired,
+  showHiddenColumnMarkers: PropTypes.bool,
   rowData: PropTypes.object.isRequired,
   linkRowsToDatasetView: PropTypes.bool,
   showRowDragControls: PropTypes.bool,
@@ -124,6 +146,7 @@ DataRow.propTypes = {
 };
 
 DataRow.defaultProps = {
+  showHiddenColumnMarkers: false,
   linkRowsToDatasetView: false,
   showRowDragControls: false,
   isDragging: false,

--- a/src/components/partials/DatasetTable.jsx
+++ b/src/components/partials/DatasetTable.jsx
@@ -12,6 +12,8 @@ import DatasetTableContextMenu from "./DatasetTableContextMenu";
 import {
   applyPreviewRowOrder,
   getDatasetRowKey,
+  getHiddenColumnMarkerLabel,
+  getPreviewTableColumnSegments,
   isVisibleColumnOrderCustom,
   mergeVisibleColumnReorder,
   orderColumnKeys,
@@ -114,6 +116,41 @@ class DatasetTable extends React.Component {
     return sortDirection === "asc" ? "ascending" : "descending";
   }
 
+  handleUnhideHiddenColumns(e, hiddenColumnNames) {
+    e.preventDefault();
+    e.stopPropagation();
+    const { showHiddenColumns } = this.props;
+    if (!showHiddenColumns || !hiddenColumnNames?.length) return;
+    showHiddenColumns(hiddenColumnNames);
+  }
+
+  renderHiddenColumnsMarker(segment, segmentIndex) {
+    const { columnKeys } = this.props;
+    const { columnNames } = segment;
+    const label = getHiddenColumnMarkerLabel(columnNames, columnKeys);
+    const markerKey = `hidden-${segmentIndex}-${columnNames.join("|")}`;
+
+    return (
+      <th
+        key={markerKey}
+        className="dataset-table__hidden-columns-marker"
+        title={label}
+        aria-label={label}
+        data-hidden-count={columnNames.length > 1 ? columnNames.length : undefined}
+        tabIndex={0}
+        onClick={(e) => this.handleUnhideHiddenColumns(e, columnNames)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            this.handleUnhideHiddenColumns(e, columnNames);
+          }
+        }}
+      >
+        <span className="dataset-table__hidden-columns-marker__line" aria-hidden />
+      </th>
+    );
+  }
+
   renderVisibleHeader(header, visibleIndex, columnNames) {
     const { sortColumn } = this.state;
     const isSorted = sortColumn === header.name;
@@ -156,11 +193,19 @@ class DatasetTable extends React.Component {
     );
   }
 
-  setTableHeaders(orderedColumnKeys) {
-    const columnNames = orderedColumnKeys.map((col) => col.name);
-    return orderedColumnKeys.map((header, index) =>
-      this.renderVisibleHeader(header, index, columnNames),
-    );
+  buildTableHeaderCells(columnSegments, columnNames, showHiddenColumnMarkers) {
+    let visibleIndex = 0;
+
+    return columnSegments.flatMap((segment, segmentIndex) => {
+      if (segment.type === "hidden") {
+        if (!showHiddenColumnMarkers) return [];
+        return [this.renderHiddenColumnsMarker(segment, segmentIndex)];
+      }
+
+      const cell = this.renderVisibleHeader(segment.column, visibleIndex, columnNames);
+      visibleIndex += 1;
+      return [cell];
+    });
   }
 
   handleColumnDragStart(e, index) {
@@ -299,6 +344,7 @@ class DatasetTable extends React.Component {
       linkRowsToDatasetView = false,
       updatePage,
       updateSelectedColumns,
+      showHiddenColumns,
       previewColumnOrder = [],
       previewRowOrder = [],
       onPreviewColumnOrderChange,
@@ -308,6 +354,10 @@ class DatasetTable extends React.Component {
     const { sortColumn, sortDirection, inputPageNum, contextMenu, dragRowIndex } = this.state;
 
     const orderedColumnKeys = orderColumnKeys(columnKeys, selectedColumns, previewColumnOrder);
+    const columnSegments = getPreviewTableColumnSegments(previewColumnOrder, columnKeys, selectedColumns);
+    const showHiddenColumnMarkers = Boolean(
+      showHiddenColumns && columnSegments.some((segment) => segment.type === "hidden"),
+    );
     const hasVisibleColumns = orderedColumnKeys.length > 0;
 
     // Avoid a broken table (row drag gutter only) when all columns are deselected.
@@ -345,7 +395,11 @@ class DatasetTable extends React.Component {
     }
 
     const visibleColumnNames = orderedColumnKeys.map((col) => col.name);
-    const renderedHeaders = this.setTableHeaders(orderedColumnKeys);
+    const renderedHeaders = this.buildTableHeaderCells(
+      columnSegments,
+      visibleColumnNames,
+      showHiddenColumnMarkers,
+    );
     const selectedYearsSet = new Set(selectedYears);
 
     let allRows;
@@ -384,7 +438,8 @@ class DatasetTable extends React.Component {
       <DataRow
         key={rowKeysInView[i]}
         rowData={row}
-        headers={visibleColumnNames}
+        columnSegments={columnSegments}
+        showHiddenColumnMarkers={showHiddenColumnMarkers}
         linkRowsToDatasetView={linkRowsToDatasetView}
         showRowDragControls={showRowDragControls}
         isDragging={dragRowIndex === i}
@@ -527,6 +582,7 @@ DatasetTable.propTypes = {
   linkRowsToDatasetView: PropTypes.bool,
   updatePage: PropTypes.func.isRequired,
   updateSelectedColumns: PropTypes.func,
+  showHiddenColumns: PropTypes.func,
   previewColumnOrder: PropTypes.arrayOf(PropTypes.string),
   previewRowOrder: PropTypes.arrayOf(PropTypes.string),
   onPreviewColumnOrderChange: PropTypes.func,

--- a/src/components/partials/DatasetTable.jsx
+++ b/src/components/partials/DatasetTable.jsx
@@ -1,12 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faArrowDown, faArrowUp, faArrowsUpDown, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import {
+  faArrowDown,
+  faArrowUp,
+  faChevronDown,
+  faEyeSlash,
+} from "@fortawesome/free-solid-svg-icons";
 import DataRow from "./DataRow";
 import DatasetTableContextMenu from "./DatasetTableContextMenu";
 import {
   applyPreviewRowOrder,
   getDatasetRowKey,
+  isVisibleColumnOrderCustom,
+  mergeVisibleColumnReorder,
   orderColumnKeys,
   reorderList,
 } from "../../utils/datasetTablePreview";
@@ -26,7 +33,7 @@ class DatasetTable extends React.Component {
     this.onPageNumberUpdate = this.onPageNumberUpdate.bind(this);
     this.onPageNumberBlur = this.onPageNumberBlur.bind(this);
     this.closeContextMenu = this.closeContextMenu.bind(this);
-    this.openColumnContextMenu = this.openColumnContextMenu.bind(this);
+    this.openColumnHeaderMenu = this.openColumnHeaderMenu.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -39,25 +46,39 @@ class DatasetTable extends React.Component {
     this.setState({ contextMenu: null });
   }
 
-  openColumnContextMenu(e, column) {
+  openColumnHeaderMenu(e, column) {
     e.preventDefault();
     e.stopPropagation();
-    const { updateSelectedColumns } = this.props;
-    if (!updateSelectedColumns) return;
+    const { sortColumn, sortDirection } = this.state;
+    const { updateSelectedColumns, selectedColumns } = this.props;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const isSorted = sortColumn === column.name;
+    const sortAscendingNext = !isSorted || sortDirection === "desc";
+
+    const items = [
+      {
+        label: sortAscendingNext
+          ? "Sort this column in ascending order"
+          : "Sort this column in descending order",
+        icon: sortAscendingNext ? faArrowUp : faArrowDown,
+        onSelect: () => this.handleSort(column.name),
+      },
+    ];
+
+    if (updateSelectedColumns && selectedColumns.includes(column.name)) {
+      items.push({
+        label: "Hide this column",
+        icon: faEyeSlash,
+        onSelect: () => updateSelectedColumns(column.name),
+      });
+    }
+
     this.setState({
       contextMenu: {
-        x: e.clientX,
-        y: e.clientY,
-        items: [
-          {
-            label: "Hide column",
-            onSelect: () => {
-              if (this.props.selectedColumns.includes(column.name)) {
-                updateSelectedColumns(column.name);
-              }
-            },
-          },
-        ],
+        x: rect.left,
+        y: rect.bottom + 4,
+        columnName: column.name,
+        items,
       },
     });
   }
@@ -79,28 +100,12 @@ class DatasetTable extends React.Component {
     });
   }
 
-  getSortIcon(columnName) {
+  getHeaderMenuIcon(columnName) {
     const { sortColumn, sortDirection } = this.state;
     if (sortColumn !== columnName) {
-      return <FontAwesomeIcon icon={faArrowsUpDown} className="sort-icon sort-icon--inactive" size="sm" aria-hidden />;
+      return faChevronDown;
     }
-    return sortDirection === "asc" ? (
-      <FontAwesomeIcon icon={faArrowUp} className="sort-icon sort-icon--active" size="sm" aria-hidden />
-    ) : (
-      <FontAwesomeIcon icon={faArrowDown} className="sort-icon sort-icon--active" size="sm" aria-hidden />
-    );
-  }
-
-  getSortTooltip(columnName, columnAlias) {
-    const { sortColumn, sortDirection } = this.state;
-    const label = columnAlias || columnName;
-    if (sortColumn !== columnName) {
-      return `Sort ascending by ${label}`;
-    }
-    if (sortDirection === "asc") {
-      return `Sorted ascending by ${label}. Click to sort descending.`;
-    }
-    return `Sorted descending by ${label}. Click to sort ascending.`;
+    return sortDirection === "asc" ? faArrowUp : faArrowDown;
   }
 
   getAriaSort(columnName) {
@@ -109,12 +114,53 @@ class DatasetTable extends React.Component {
     return sortDirection === "asc" ? "ascending" : "descending";
   }
 
-  handleHideColumnClick(e, column) {
-    e.preventDefault();
-    e.stopPropagation();
-    const { updateSelectedColumns, selectedColumns } = this.props;
-    if (!updateSelectedColumns || !selectedColumns.includes(column.name)) return;
-    updateSelectedColumns(column.name);
+  renderVisibleHeader(header, visibleIndex, columnNames) {
+    const { sortColumn } = this.state;
+    const isSorted = sortColumn === header.name;
+
+    return (
+      <th
+        className={`ui table sortable-header dataset-table__header${this.state.dragColumnIndex === visibleIndex ? " dataset-table__header--dragging" : ""}`}
+        key={header.name}
+        aria-sort={this.getAriaSort(header.name)}
+        onDragOver={this.handleColumnDragOver}
+        onDrop={(e) => this.handleColumnDrop(e, visibleIndex, columnNames)}
+      >
+        <div className="header-content">
+          <span
+            className="dataset-table__drag-grip"
+            draggable
+            onDragStart={(e) => this.handleColumnDragStart(e, visibleIndex)}
+            onDragEnd={() => this.setState({ dragColumnIndex: null })}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            title="Drag to reorder column"
+            aria-label="Drag to reorder column"
+          />
+          <span className="dataset-table__header-label">{header.alias}</span>
+          <div className="dataset-table__header-actions">
+            <button
+              type="button"
+              className={`dataset-table__header-menu-btn${isSorted ? " dataset-table__header-menu-btn--sorted" : ""}`}
+              title={`Column options for ${header.alias}`}
+              aria-label={`Column options for ${header.alias}`}
+              aria-haspopup="menu"
+              aria-expanded={this.state.contextMenu?.columnName === header.name}
+              onClick={(e) => this.openColumnHeaderMenu(e, header)}
+            >
+              <FontAwesomeIcon icon={this.getHeaderMenuIcon(header.name)} size="sm" aria-hidden />
+            </button>
+          </div>
+        </div>
+      </th>
+    );
+  }
+
+  setTableHeaders(orderedColumnKeys) {
+    const columnNames = orderedColumnKeys.map((col) => col.name);
+    return orderedColumnKeys.map((header, index) =>
+      this.renderVisibleHeader(header, index, columnNames),
+    );
   }
 
   handleColumnDragStart(e, index) {
@@ -134,14 +180,18 @@ class DatasetTable extends React.Component {
     const { previewColumnOrder, onPreviewColumnOrderChange } = this.props;
     if (dragColumnIndex == null || !onPreviewColumnOrderChange || !columnNames?.length) return;
 
-    const order = previewColumnOrder?.length
+    const visibleOrder = previewColumnOrder?.length
       ? previewColumnOrder.filter((name) => columnNames.includes(name))
       : [...columnNames];
     columnNames.forEach((name) => {
-      if (!order.includes(name)) order.push(name);
+      if (!visibleOrder.includes(name)) visibleOrder.push(name);
     });
 
-    onPreviewColumnOrderChange(reorderList(order, dragColumnIndex, toIndex));
+    const reorderedVisible = reorderList(visibleOrder, dragColumnIndex, toIndex);
+    const fullOrder = previewColumnOrder?.length ? previewColumnOrder : [...columnNames];
+    const nextOrder = mergeVisibleColumnReorder(fullOrder, columnNames, reorderedVisible);
+
+    onPreviewColumnOrderChange(nextOrder);
     this.setState({ dragColumnIndex: null });
   }
 
@@ -171,50 +221,6 @@ class DatasetTable extends React.Component {
     this.setState({ dragRowIndex: null });
   }
 
-  setTableHeaders(orderedColumnKeys) {
-    const columnNames = orderedColumnKeys.map((col) => col.name);
-    return orderedColumnKeys.map((header, index) => (
-      <th
-        className={`ui table sortable-header dataset-table__header${this.state.dragColumnIndex === index ? " dataset-table__header--dragging" : ""}`}
-        key={header.name}
-        title={this.getSortTooltip(header.name, header.alias)}
-        aria-sort={this.getAriaSort(header.name)}
-        onClick={() => this.handleSort(header.name)}
-        onContextMenu={(e) => this.openColumnContextMenu(e, header)}
-        onDragOver={this.handleColumnDragOver}
-        onDrop={(e) => this.handleColumnDrop(e, index, columnNames)}
-        style={{ cursor: "pointer" }}
-      >
-        <div className="header-content">
-          <span
-            className="dataset-table__drag-grip"
-            draggable
-            onDragStart={(e) => this.handleColumnDragStart(e, index)}
-            onDragEnd={() => this.setState({ dragColumnIndex: null })}
-            onMouseDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
-            title="Drag to reorder column"
-            aria-label="Drag to reorder column"
-          />
-          <span className="dataset-table__header-label">{header.alias}</span>
-          <div className="dataset-table__header-actions">
-            <span className="sort-icon-wrap" title={this.getSortTooltip(header.name, header.alias)} aria-hidden>
-              {this.getSortIcon(header.name)}
-            </span>
-            <button
-              type="button"
-              className="dataset-table__hide-btn"
-              title="Hide column"
-              aria-label={`Hide column ${header.alias}`}
-              onClick={(e) => this.handleHideColumnClick(e, header)}
-            >
-              <FontAwesomeIcon icon={faEyeSlash} size="sm" aria-hidden />
-            </button>
-          </div>
-        </div>
-      </th>
-    ));
-  }
 
   sortData(data, columnName, direction) {
     if (!columnName) return data;
@@ -302,29 +308,15 @@ class DatasetTable extends React.Component {
     const { sortColumn, sortDirection, inputPageNum, contextMenu, dragRowIndex } = this.state;
 
     const orderedColumnKeys = orderColumnKeys(columnKeys, selectedColumns, previewColumnOrder);
+    const hasVisibleColumns = orderedColumnKeys.length > 0;
 
     // Avoid a broken table (row drag gutter only) when all columns are deselected.
-    if (columnKeys.length > 0 && orderedColumnKeys.length === 0) {
-      const showRowPreviewControls = Boolean(updateSelectedColumns || onPreviewRowOrderChange);
-    const canCustomizeLayout = Boolean(
-        showRowPreviewControls || onPreviewColumnOrderChange,
-      );
-      const defaultColumnNames = orderedColumnKeys.map((col) => col.name);
-      const columnOrderCustom =
-        previewColumnOrder.length > 0 && previewColumnOrder.join("|") !== defaultColumnNames.join("|");
-      const hasPreviewCustomization = columnOrderCustom || previewRowOrder.length > 0;
+    if (columnKeys.length > 0 && !hasVisibleColumns) {
       const isEmbedView = new URLSearchParams(location.search).get("embed") === "1";
 
       return (
         <div className="table-wrapper">
           <DatasetTableContextMenu menu={contextMenu} onClose={this.closeContextMenu} />
-          {canCustomizeLayout && hasPreviewCustomization && onResetPreviewLayout ? (
-            <div className="dataset-table-preview-toolbar">
-              <button type="button" className="dataset-table-preview-toolbar__reset" onClick={onResetPreviewLayout}>
-                Reset table layout
-              </button>
-            </div>
-          ) : null}
           <div className="container tight">
             <div className="scroll-horizontal-rotated ui lift">
               <div className="cancel-rotate">
@@ -352,6 +344,7 @@ class DatasetTable extends React.Component {
       );
     }
 
+    const visibleColumnNames = orderedColumnKeys.map((col) => col.name);
     const renderedHeaders = this.setTableHeaders(orderedColumnKeys);
     const selectedYearsSet = new Set(selectedYears);
 
@@ -391,7 +384,7 @@ class DatasetTable extends React.Component {
       <DataRow
         key={rowKeysInView[i]}
         rowData={row}
-        headers={orderedColumnKeys.map((key) => key.name)}
+        headers={visibleColumnNames}
         linkRowsToDatasetView={linkRowsToDatasetView}
         showRowDragControls={showRowDragControls}
         isDragging={dragRowIndex === i}
@@ -409,15 +402,17 @@ class DatasetTable extends React.Component {
     const backButtonClasses = currentPage === 1 ? "button-wrapper lift disabled" : "button-wrapper lift";
     const forwardButtonClasses = currentPage === numOfPages ? "button-wrapper list disabled" : "button-wrapper lift";
     const isEmbedView = new URLSearchParams(location.search).get("embed") === "1";
-    const defaultColumnNames = orderedColumnKeys.map((col) => col.name);
-    const columnOrderCustom =
-      previewColumnOrder.length > 0 && previewColumnOrder.join("|") !== defaultColumnNames.join("|");
+    const columnOrderCustom = isVisibleColumnOrderCustom(
+      previewColumnOrder,
+      visibleColumnNames,
+      columnKeys,
+    );
     const hasPreviewCustomization = columnOrderCustom || previewRowOrder.length > 0;
 
     return (
       <div className="table-wrapper">
         <DatasetTableContextMenu menu={contextMenu} onClose={this.closeContextMenu} />
-        {canCustomizeLayout && hasPreviewCustomization && onResetPreviewLayout ? (
+        {hasVisibleColumns && canCustomizeLayout && hasPreviewCustomization && onResetPreviewLayout ? (
           <div className="dataset-table-preview-toolbar">
             <button type="button" className="dataset-table-preview-toolbar__reset" onClick={onResetPreviewLayout}>
               Reset table layout

--- a/src/components/partials/DatasetTableContextMenu.jsx
+++ b/src/components/partials/DatasetTableContextMenu.jsx
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export default function DatasetTableContextMenu({ menu, onClose }) {
   if (!menu) return null;
@@ -25,15 +26,20 @@ export default function DatasetTableContextMenu({ menu, onClose }) {
         style={{ top: menu.y, left: menu.x }}
         role="menu"
       >
-        {menu.items.map((item) => (
+        {menu.items.map((item, index) => (
           <button
-            key={item.label}
+            key={`${item.label}-${index}`}
             type="button"
             role="menuitem"
             className="dataset-table-context-menu__item"
             onClick={() => handleAction(item.onSelect)}
           >
-            {item.label}
+            {item.icon ? (
+              <span className="dataset-table-context-menu__icon" aria-hidden>
+                <FontAwesomeIcon icon={item.icon} size="sm" />
+              </span>
+            ) : null}
+            <span className="dataset-table-context-menu__label">{item.label}</span>
           </button>
         ))}
       </div>
@@ -48,6 +54,7 @@ DatasetTableContextMenu.propTypes = {
     items: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,
+        icon: PropTypes.object,
         onSelect: PropTypes.func.isRequired,
       }),
     ).isRequired,

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -39,6 +39,7 @@ class DataViewerClass extends React.Component {
     };
     this.updateSelectedYears = this.updateSelectedYears.bind(this);
     this.updateSelectedColumns = this.updateSelectedColumns.bind(this);
+    this.showHiddenColumns = this.showHiddenColumns.bind(this);
     this.updatePage = this.updatePage.bind(this);
     this.updateRowsPerPage = this.updateRowsPerPage.bind(this);
     this.loadDatasetData = this.loadDatasetData.bind(this);
@@ -382,6 +383,30 @@ class DataViewerClass extends React.Component {
     });
   }
 
+  showHiddenColumns(columnNames) {
+    if (!columnNames?.length) return;
+
+    this.setState((prevState) => {
+      const marginColumnsByBase = prevState.marginColumnsByBase || {};
+      let selectedColumns = [...prevState.selectedColumns];
+
+      columnNames.forEach((columnName) => {
+        if (selectedColumns.includes(columnName)) return;
+        selectedColumns.push(columnName);
+        (marginColumnsByBase[columnName] || []).forEach((col) => {
+          if (!selectedColumns.includes(col)) selectedColumns.push(col);
+        });
+      });
+
+      const previewColumnOrder = syncPreviewColumnOrder(
+        prevState.previewColumnOrder,
+        selectedColumns,
+        prevState.columnKeys,
+      );
+      return { selectedColumns, previewColumnOrder };
+    });
+  }
+
   onPreviewColumnOrderChange(previewColumnOrder) {
     this.setState({ previewColumnOrder });
   }
@@ -484,6 +509,7 @@ class DataViewerClass extends React.Component {
             linkRowsToDatasetView={this.state.linkInventoryRows}
             updatePage={this.updatePage}
             updateSelectedColumns={this.updateSelectedColumns}
+            showHiddenColumns={this.showHiddenColumns}
             previewColumnOrder={this.state.previewColumnOrder}
             previewRowOrder={this.state.previewRowOrder}
             onPreviewColumnOrderChange={this.onPreviewColumnOrderChange}

--- a/src/utils/datasetTablePreview.js
+++ b/src/utils/datasetTablePreview.js
@@ -35,21 +35,70 @@ export function getDatasetRowKey(row, fallbackIndex = 0) {
   }
 }
 
-/** Keep custom column order in sync when selection changes. */
-export function syncPreviewColumnOrder(prevOrder, selectedColumns, columnKeys) {
-  const selectedSet = new Set(selectedColumns || []);
-  const kept = (prevOrder || []).filter((name) => selectedSet.has(name));
-  const keptSet = new Set(kept);
-  const added = (columnKeys || [])
+/**
+ * user selected column(includes hidden/deselected columns).
+ * Deselected columns stay in place so re-adding restores their prior position.
+ */
+export function syncPreviewColumnOrder(prevOrder, _selectedColumns, columnKeys) {
+  const allColumnNames = columnKeys.map((col) => col.name);
+  const columnKeySet = new Set(allColumnNames);
+  // Filter out columns that are not in the columnKeys
+  const order = prevOrder.filter((name) => columnKeySet.has(name));
+
+  allColumnNames.forEach((name) => {
+    if (!order.includes(name)) {
+      order.push(name);
+    }
+  });
+
+  return order;
+}
+
+/**
+ * Apply a reorder of visible columns while keeping hidden columns at their slots.
+ */
+export function mergeVisibleColumnReorder(fullOrder, visibleColumnNames, reorderedVisible) {
+  const visibleSet = new Set(visibleColumnNames);
+  const queue = [...reorderedVisible];
+  const merged = [];
+
+  fullOrder.forEach((name) => {
+    if (visibleSet.has(name)) {
+      if (queue.length) merged.push(queue.shift());
+    } else {
+      merged.push(name);
+    }
+  });
+
+  queue.forEach((name) => merged.push(name));
+  return merged;
+}
+
+/**
+ * True when visible columns are ordered differently than metadata default.
+ * Compares layout (previewColumnOrder) to columnKeys order — not to the already-rendered order.
+ */
+export function isVisibleColumnOrderCustom(previewColumnOrder, visibleColumnNames, columnKeys) {
+  if (!visibleColumnNames?.length) return false;
+
+  const visibleSet = new Set(visibleColumnNames);
+  const defaultVisibleOrder = (columnKeys || [])
     .map((col) => col.name)
-    .filter((name) => selectedSet.has(name) && !keptSet.has(name));
-  return [...kept, ...added];
+    .filter((name) => visibleSet.has(name));
+
+  const layoutVisibleOrder = (previewColumnOrder || []).filter((name) => visibleSet.has(name));
+  const currentVisibleOrder =
+    layoutVisibleOrder.length === defaultVisibleOrder.length
+      ? layoutVisibleOrder
+      : defaultVisibleOrder;
+
+  return currentVisibleOrder.join("|") !== defaultVisibleOrder.join("|");
 }
 
 export function orderColumnKeys(columnKeys, selectedColumns, previewColumnOrder) {
   const selectedSet = new Set(selectedColumns || []);
-  const visible = (columnKeys || []).filter((col) => selectedSet.has(col.name));
-  if (!previewColumnOrder?.length) return visible;
+  const visible = columnKeys.filter((col) => selectedSet.has(col.name));
+  if (!previewColumnOrder.length) return visible;
 
   const byName = new Map(visible.map((col) => [col.name, col]));
   const ordered = [];
@@ -65,9 +114,9 @@ export function orderColumnKeys(columnKeys, selectedColumns, previewColumnOrder)
 
 /** Merge custom row order with filtered rows; append rows not yet in order. */
 export function applyPreviewRowOrder(rows, previewRowOrder) {
-  const visible = (rows || []).map((row, i) => ({ row, key: getDatasetRowKey(row, i) }));
+  const visible = (rows).map((row, i) => ({ row, key: getDatasetRowKey(row, i) }));
 
-  if (!previewRowOrder?.length) return visible.map(({ row }) => row);
+  if (!previewRowOrder.length) return visible.map(({ row }) => row);
 
   const buckets = new Map();
   visible.forEach(({ row, key }) => {
@@ -89,7 +138,7 @@ export function applyPreviewRowOrder(rows, previewRowOrder) {
 }
 
 export function reorderList(list, fromIndex, toIndex) {
-  if (!list?.length || fromIndex === toIndex || fromIndex < 0 || toIndex < 0) return list;
+  if (!list.length || fromIndex === toIndex || fromIndex < 0 || toIndex < 0) return list;
   const next = [...list];
   if (fromIndex >= next.length || toIndex >= next.length) return list;
   const [item] = next.splice(fromIndex, 1);

--- a/src/utils/datasetTablePreview.js
+++ b/src/utils/datasetTablePreview.js
@@ -82,11 +82,11 @@ export function isVisibleColumnOrderCustom(previewColumnOrder, visibleColumnName
   if (!visibleColumnNames?.length) return false;
 
   const visibleSet = new Set(visibleColumnNames);
-  const defaultVisibleOrder = (columnKeys || [])
+  const defaultVisibleOrder = columnKeys
     .map((col) => col.name)
     .filter((name) => visibleSet.has(name));
 
-  const layoutVisibleOrder = (previewColumnOrder || []).filter((name) => visibleSet.has(name));
+  const layoutVisibleOrder = previewColumnOrder.filter((name) => visibleSet.has(name));
   const currentVisibleOrder =
     layoutVisibleOrder.length === defaultVisibleOrder.length
       ? layoutVisibleOrder
@@ -95,52 +95,126 @@ export function isVisibleColumnOrderCustom(previewColumnOrder, visibleColumnName
   return currentVisibleOrder.join("|") !== defaultVisibleOrder.join("|");
 }
 
+/**
+ * Get the column segments for the preview table.
+ */
+export function getPreviewTableColumnSegments(previewColumnOrder, columnKeys, selectedColumns) {
+  const selectedSet = new Set(selectedColumns);
+  const columnNameToColumn = new Map((columnKeys).map((col) => [col.name, col]));
+  const layoutOrder = previewColumnOrder?.length
+    ? previewColumnOrder.filter((name) => columnNameToColumn.has(name))
+    : columnKeys.map((col) => col.name);
+
+  const segments = [];
+  let hiddenColumns = [];
+  
+  const flushHiddenColumns = () => {
+    if (!hiddenColumns.length) return;
+    segments.push({ type: "hidden", columnNames: [...hiddenColumns] });
+    hiddenColumns = [];
+  };
+
+  layoutOrder.forEach((name) => {
+    if (selectedSet.has(name)) {
+      flushHiddenColumns();
+      const col = columnNameToColumn.get(name);
+      if (col) segments.push({ type: "visible", column: col });
+    } else {
+      hiddenColumns.push(name);
+    }
+  });
+  flushHiddenColumns();
+
+  return segments;
+}
+
+export function getHiddenColumnMarkerLabel(hiddenColumnNames, columnKeys) {
+  const aliases = hiddenColumnNames.map((name) => {
+    const col = columnKeys.find((c) => c.name === name);
+    return col?.alias || name;
+  });
+  if (!aliases.length) return "Show hidden columns";
+  if (aliases.length === 1) return `Show hidden column: ${aliases[0]}`;
+  return `Show ${aliases.length} hidden columns (${aliases.join(", ")})`;
+}
+
 export function orderColumnKeys(columnKeys, selectedColumns, previewColumnOrder) {
-  const selectedSet = new Set(selectedColumns || []);
+  const selectedSet = new Set(selectedColumns);
   const visible = columnKeys.filter((col) => selectedSet.has(col.name));
   if (!previewColumnOrder.length) return visible;
 
-  const byName = new Map(visible.map((col) => [col.name, col]));
+  const columnNameToColumnMap = new Map(visible.map((col) => [col.name, col]));
   const ordered = [];
   previewColumnOrder.forEach((name) => {
-    if (byName.has(name)) {
-      ordered.push(byName.get(name));
-      byName.delete(name);
+    if (columnNameToColumnMap.has(name)) {
+      ordered.push(columnNameToColumnMap.get(name));
+      columnNameToColumnMap.delete(name);
     }
   });
-  byName.forEach((col) => ordered.push(col));
+  columnNameToColumnMap.forEach((col) => ordered.push(col));
   return ordered;
 }
 
 /** Merge custom row order with filtered rows; append rows not yet in order. */
 export function applyPreviewRowOrder(rows, previewRowOrder) {
-  const visible = (rows).map((row, i) => ({ row, key: getDatasetRowKey(row, i) }));
+  const rowsWithStableKeys = rows.map((row, rowIndex) => ({
+    row,
+    stableRowKey: getDatasetRowKey(row, rowIndex),
+  }));
 
-  if (!previewRowOrder.length) return visible.map(({ row }) => row);
+  if (!previewRowOrder.length) {
+    return rowsWithStableKeys.map(({ row }) => row);
+  }
 
-  const buckets = new Map();
-  visible.forEach(({ row, key }) => {
-    if (!buckets.has(key)) buckets.set(key, []);
-    buckets.get(key).push(row);
+  // Group rows by drag key; multiple rows can share the same key.
+  const rowQueuesByStableKey = new Map();
+  rowsWithStableKeys.forEach(({ row, stableRowKey }) => {
+    if (!rowQueuesByStableKey.has(stableRowKey)) {
+      rowQueuesByStableKey.set(stableRowKey, []);
+    }
+    rowQueuesByStableKey.get(stableRowKey).push(row);
   });
 
-  const ordered = [];
-  previewRowOrder.forEach((key) => {
-    const bucket = buckets.get(key);
-    if (!bucket?.length) return;
-    ordered.push(bucket.shift());
-    if (!bucket.length) buckets.delete(key);
+  const rowsInSavedOrder = [];
+  previewRowOrder.forEach((savedRowKey) => {
+    const queuedRowsForKey = rowQueuesByStableKey.get(savedRowKey);
+    if (!queuedRowsForKey?.length) {
+      return;
+    }
+    rowsInSavedOrder.push(queuedRowsForKey.shift());
+    if (!queuedRowsForKey.length) {
+      rowQueuesByStableKey.delete(savedRowKey);
+    }
   });
-  buckets.forEach((bucket) => {
-    bucket.forEach((row) => ordered.push(row));
+
+  rowQueuesByStableKey.forEach((remainingRowsForKey) => {
+    remainingRowsForKey.forEach((row) => rowsInSavedOrder.push(row));
   });
-  return ordered;
+
+  return rowsInSavedOrder;
 }
 
 export function reorderList(list, fromIndex, toIndex) {
-  if (!list.length || fromIndex === toIndex || fromIndex < 0 || toIndex < 0) return list;
+  if (!list.length) {
+    return list;
+  }
+  // No change
+  if (fromIndex === toIndex) {
+    return list;
+  }
+  if (fromIndex < 0 || toIndex < 0) {
+    return list;
+  }
+
   const next = [...list];
-  if (fromIndex >= next.length || toIndex >= next.length) return list;
+  
+  if (fromIndex >= next.length) {
+    return list;
+  }
+  if (toIndex >= next.length) {
+    return list;
+  }
+
   const [item] = next.splice(fromIndex, 1);
   next.splice(toIndex, 0, item);
   return next;


### PR DESCRIPTION
<img width="1370" height="514" alt="Screenshot 2026-06-03 at 1 48 23 PM" src="https://github.com/user-attachments/assets/d40f5b44-ebbf-4e5b-92a3-f0b4e3c39b84" />

The previous hidden-column behavior was not very intuitive, so I adopted an Excel-style indicator to make hidden columns more visible.

Now, when users uncheck columns from the dropdown or click the hide icon in the table, a green line and tooltip will appear in the table header to clearly indicate which columns are hidden.