### PR TITLE
update override map color and panel info

### DIFF
--- a/src/assets/styles/components/Tab.scss
+++ b/src/assets/styles/components/Tab.scss
@@ -43,6 +43,8 @@
         min-width: 220px;
         max-width: 320px;
         box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
         padding: 0.85rem 1rem;
         border: 1px solid rgba(0, 0, 0, 0.12);
         border-radius: 4px;
@@ -50,6 +52,10 @@
         font-family: skolar-sans-latin, Helvetica, sans-serif;
         line-height: 1.45;
         color: #333;
+      }
+
+      .municipal-finance-overrides-map__sidebar-body {
+        flex: 1 1 auto;
       }
 
       .municipal-finance-overrides-map__sidebar-title {
@@ -90,6 +96,25 @@
         font-size: 0.8125rem;
         line-height: 1.4;
         color: #64748b;
+      }
+
+      .municipal-finance-overrides-map__source {
+        margin-top: 1rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid rgba(0, 0, 0, 0.08);
+        font-size: 0.75rem;
+
+        .source-timeframe {
+          display: block;
+        }
+
+        .link {
+          margin-top: 0.35rem;
+
+          a {
+            text-decoration: underline;
+          }
+        }
       }
 
       .municipal-finance-overrides-map__hint {

--- a/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
+++ b/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
@@ -368,7 +368,6 @@ export default function MunicipalFinanceOverridesMap({ config, municipalFeature 
         yearsUrl = `${yearsUrl}&filters=ovr_winamt!!,ovr_losamt!!,rev_total!!,exp_total!!`;
         const yearResp = await fetch(yearsUrl);
         const yearPayload = (await yearResp.json()) || {};
-        console.log("yearPayload", yearPayload);
         const latestYear = yearPayload.rows[0].fiscal_yr 
         const y = latestYear;
 

--- a/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
+++ b/src/components/visualizations/MunicipalFinanceOverridesMap.jsx
@@ -237,7 +237,7 @@ export default function MunicipalFinanceOverridesMap({ config, municipalFeature 
     : "";
 
   const selectedProfileUrl = selectedDisplayName
-    ? `/profile/${muniProfileSlug(selectedDisplayName)}`
+    ? `/profile/${muniProfileSlug(selectedDisplayName)}/municipal-finance`
     : null;
 
   const latestDataRef = useRef({
@@ -368,7 +368,8 @@ export default function MunicipalFinanceOverridesMap({ config, municipalFeature 
         yearsUrl = `${yearsUrl}&filters=ovr_winamt!!,ovr_losamt!!,rev_total!!,exp_total!!`;
         const yearResp = await fetch(yearsUrl);
         const yearPayload = (await yearResp.json()) || {};
-        const latestYear = yearPayload.rows.length === 1 ? yearPayload.rows[0].fiscal_yr : 2023;
+        console.log("yearPayload", yearPayload);
+        const latestYear = yearPayload.rows[0].fiscal_yr 
         const y = latestYear;
 
         if (!Number.isFinite(y)) {
@@ -690,33 +691,64 @@ export default function MunicipalFinanceOverridesMap({ config, municipalFeature 
           aria-live="polite"
           aria-label="Municipality override details"
         >
-          {selectedProperties ? (
-            <>
-              <strong className="municipal-finance-overrides-map__sidebar-title">{selectedDisplayName}</strong>
-              <dl className="municipal-finance-overrides-map__sidebar-fields">
-                {sidebarFields.map((field) => (
-                  <div key={field.key} className="municipal-finance-overrides-map__sidebar-row">
-                    <dt>{field.label}</dt>
-                    <dd>{field.value}</dd>
-                  </div>
+          <div className="municipal-finance-overrides-map__sidebar-body">
+            {selectedProperties ? (
+              <>
+                <strong className="municipal-finance-overrides-map__sidebar-title">{selectedDisplayName}</strong>
+                <dl className="municipal-finance-overrides-map__sidebar-fields">
+                  {sidebarFields.map((field) => (
+                    <div key={field.key} className="municipal-finance-overrides-map__sidebar-row">
+                      <dt>{field.label}</dt>
+                      <dd>{field.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+                {selectedProfileUrl ? (
+                  <a
+                    className="municipal-finance-overrides-map__sidebar-link"
+                    href={selectedProfileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View community profile
+                  </a>
+                ) : null}
+              </>
+            ) : (
+              <p className="municipal-finance-overrides-map__sidebar-empty">
+                Click a municipality on the map to see total revenue, expenditures, and override amounts.
+              </p>
+            )}
+          </div>
+          <div className="metadata municipal-finance-overrides-map__source">
+            <div className="source-timeframe">
+              <div className="source">
+                Source:
+                {" "}
+                {config.source || "Unknown"}
+              </div>
+              <div className="timeframe">
+                Years:
+                {" "}
+                {fiscalYear != null ? String(fiscalYear) : "…"}
+              </div>
+            </div>
+            {config.datasetLinks ? (
+              <div className="link">
+                <span>Link to: </span>
+                {Object.keys(config.datasetLinks).map((label) => (
+                  <a
+                    key={label}
+                    href={`${window.location.origin}/browser/datasets/${config.datasetLinks[label]}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {label}
+                  </a>
                 ))}
-              </dl>
-              {selectedProfileUrl ? (
-                <a
-                  className="municipal-finance-overrides-map__sidebar-link"
-                  href={selectedProfileUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  View community profile
-                </a>
-              ) : null}
-            </>
-          ) : (
-            <p className="municipal-finance-overrides-map__sidebar-empty">
-              Click a municipality on the map to see total revenue, expenditures, and override amounts.
-            </p>
-          )}
+              </div>
+            ) : null}
+          </div>
         </aside>
       </div>
       {loading ? (
@@ -776,6 +808,8 @@ MunicipalFinanceOverridesMap.propTypes = {
     tableName: PropTypes.string.isRequired,
     mapColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     fetchLimit: PropTypes.number,
+    source: PropTypes.string,
+    datasetLinks: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     legend: PropTypes.arrayOf(
       PropTypes.shape({
         key: PropTypes.string.isRequired,

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2976,6 +2976,8 @@ export default {
       tableSchema: "tabular",
       tableName: "muni_finance_m",
       mapColumns: ["municipal", "fiscal_yr", "rev_total", "exp_total", "ovr_winamt", "ovr_losamt"],
+      source: "MA Dept of Revenue",
+      datasetLinks: { "Dept of Revenue Municipal Finance": 502 },
       legend: [
         {
           key: "success",
@@ -2985,12 +2987,12 @@ export default {
         {
           key: "loss_only",
           label: "No successful override",
-          color: colors.CHART.EXTENDED.get("LIGHT_PINK"),
+          color: "#D81B60",
         },
         {
           key: "no_overrides_attempted",
           label: "No overrides attempted",
-          color: "#cdcdcd",
+          color: "#E0E0E0",
         },
       ],
     },


### PR DESCRIPTION
- Applied a colorblind-safe color palette to the map.
- Updated the map query to use the latest year data.
- Added source information and a dataset link to the sidebar panel.
- Updated the “View the Community” link to default to the Municipal Finance tab.