### PR TITLE
show in-tile labels on large block

### DIFF
--- a/src/components/visualizations/TreeMap.jsx
+++ b/src/components/visualizations/TreeMap.jsx
@@ -581,11 +581,17 @@ class TreeMap extends React.Component {
         this.tooltip.style("opacity", 0);
       });
 
-    if (!externalLabels) {
-      leaves.each(function (d) {
-        appendTileText(d3.select(this), getTileTextLayout(d, formatValue), getTextColor(d.data));
-      });
-    }
+    // Show title + amount inside tiles that are large enough; small tiles rely on legend/tooltip.
+    const minLabelWidth =
+      chart && Number.isFinite(chart.treemapMinLabelWidth) ? chart.treemapMinLabelWidth : 88;
+    const minLabelHeight =
+      chart && Number.isFinite(chart.treemapMinLabelHeight) ? chart.treemapMinLabelHeight : 52;
+    leaves.each(function (d) {
+      const w = tileWidth(d);
+      const h = tileHeight(d);
+      if (externalLabels && (w < minLabelWidth || h < minLabelHeight)) return;
+      appendTileText(d3.select(this), getTileTextLayout(d, formatValue), getTextColor(d.data));
+    });
   }
 
   render() {

--- a/src/constants/charts.js
+++ b/src/constants/charts.js
@@ -2498,11 +2498,19 @@ export default {
     fund_revenue: {
       type: "tree-map",
       title: "Fund Revenue Breakdown",
-      // Color blocks only; labels/amounts live in the legend. Area is equal to dollar value.
+      // Area ∝ dollars. Large tiles show title + amount; small ones use legend/tooltip.
       treemapTrueProportions: true,
       treemapExternalLabels: true,
-      // Five revenue categories need five distinct colors
-      colors: Array.from(colors.CHART.PRIMARY.values()).slice(-5),
+      treemapMinLabelWidth: 88,
+      treemapMinLabelHeight: 52,
+      // Five distinct colors; use green instead of yellow for readable white labels.
+      colors: [
+        colors.CHART.PRIMARY.get("BLUE"),
+        colors.CHART.PRIMARY.get("CYAN"),
+        colors.CHART.PRIMARY.get("GREEN"),
+        colors.CHART.PRIMARY.get("PINK"),
+        colors.CHART.PRIMARY.get("DARK_RED"),
+      ],
       valueFormatter: (v) => {
         const n = typeof v === "number" ? v : Number(v);
         if (!Number.isFinite(n)) return "—";
@@ -2570,7 +2578,7 @@ export default {
           {
             summaryOnly: true,
             key: "tot_rev_display",
-            label: "Total Revenue",
+            label: "Total Receipts",
             value: totRev,
             group: "Fund Revenue",
           },


### PR DESCRIPTION
Updated the treemap to enforce a minimum block size and show labels and numbers only when there is enough space for them to be readable. Smaller blocks will remain visible but rely on tooltips or the legend for details.