### PR TITLE
add loading mask/update bulk download file name/census tract map

### DIFF
--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -582,11 +582,26 @@
   }
 
   .download-modal {
+    position: relative;
     width: min(560px, calc(100vw - 30px));
     background: #fff;
     border-radius: 10px;
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
     overflow: hidden;
+  }
+
+  .export-loading-mask {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    background: rgba(255, 255, 255, 0.82);
+    color: $color_font-medium--dark;
+    font-size: $font_size-xsmall;
   }
 
   .download-modal-header {
@@ -2180,6 +2195,13 @@
       opacity: 0.5;
       cursor: not-allowed;
     }
+  }
+
+  .dataset-map-preview__download-error {
+    margin: 8px 0 0;
+    font-size: 11px;
+    color: #b42318;
+    line-height: 1.4;
   }
 
   .dataset-map-preview__download-tooltip {

--- a/src/components/partials/DatasetMapPreview.jsx
+++ b/src/components/partials/DatasetMapPreview.jsx
@@ -14,11 +14,14 @@ import {
   enrichBoundariesWithValues,
   fetchDatasetGeometry,
   fetchGisBoundaryLayer,
+  fetchNativeCensusTractBoundaryGeojson,
   filterRowsForMapPreview,
   formatMapValue,
   getMappableColumns,
+  isNativeCensusTractBoundaryTable,
   resolveMapGeographyColumn,
 } from "../../utils/datasetMapPreview";
+import { ExportLoadingMask, useExportFileDownload } from "./ExportLoadingMask";
 
 mapboxgl.accessToken = MAP_CONFIG.accessToken;
 
@@ -62,6 +65,7 @@ function DatasetMapPreview({
   const [muniOverlayGeojson, setMuniOverlayGeojson] = useState(EMPTY_FC);
   const [mapcOverlayGeojson, setMapcOverlayGeojson] = useState(EMPTY_FC);
   const [selectedFeatureKey, setSelectedFeatureKey] = useState(null);
+  const { isExporting, exportError, runExportDownload, clearExportError } = useExportFileDownload();
 
   const filteredRows = useMemo(
     () =>
@@ -177,14 +181,24 @@ function DatasetMapPreview({
 
     const loadBoundaries = async () => {
       try {
-        const years = mapYear != null ? [mapYear] : [];
-        const result = await fetchDatasetGeometry({
-          database,
-          schema,
-          table,
-          years,
-          yearColumn: queryYearColumn || null,
-        });
+        let result;
+        if (isNativeCensusTractBoundaryTable(table)) {
+          // Boundary datasets store polygons in `shape` — draw from that column.
+          result = await fetchNativeCensusTractBoundaryGeojson({
+            database,
+            schema,
+            table,
+          });
+        } else {
+          const years = mapYear != null ? [mapYear] : [];
+          result = await fetchDatasetGeometry({
+            database,
+            schema,
+            table,
+            years,
+            yearColumn: queryYearColumn || null,
+          });
+        }
         if (cancelled) return;
         setApiBoundaryGeojson(result.featureCollection);
         setGeometryJoinKey(result.joinKey);
@@ -528,9 +542,9 @@ function DatasetMapPreview({
     };
   }, [selectedFeature, mapYear, geographyType, geometryJoinKey]);
 
-  const canDownloadGeojson = Boolean(table) && !isBoundaryLoading;
+  const canDownloadGeojson = Boolean(table) && !isBoundaryLoading && !isExporting;
 
-  const handleDownloadGeojson = () => {
+  const handleDownloadGeojson = async () => {
     if (!canDownloadGeojson) return;
 
     const params = new URLSearchParams({
@@ -545,13 +559,12 @@ function DatasetMapPreview({
       params.set("years", String(mapYear));
     }
 
-    const link = document.createElement("a");
-    link.href = `/api/export?${params.toString()}`;
-    link.rel = "noopener noreferrer";
-    link.style.display = "none";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    clearExportError();
+    const yearSuffix = mapYear != null ? `_${mapYear}` : "";
+    await runExportDownload(
+      `/api/export?${params.toString()}`,
+      `${table || "export"}${yearSuffix}.geojson`,
+    );
   };
 
   if (!geographyType) {
@@ -624,6 +637,7 @@ function DatasetMapPreview({
         </div>
         <div className="dataset-map-preview__map-body">
           <div className="dataset-map-preview__map-shell">
+            <ExportLoadingMask active={isExporting} />
             <div className="dataset-map-preview__layer-toggles" role="group" aria-label="Map overlay layers">
               <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
                 <input
@@ -716,9 +730,10 @@ function DatasetMapPreview({
                 className="dataset-map-preview__download-geojson"
                 onClick={handleDownloadGeojson}
                 disabled={!canDownloadGeojson}
+                aria-busy={isExporting}
                 aria-describedby="dataset-map-geojson-download-tip"
               >
-                Download as GeoJSON
+                {isExporting ? "Preparing…" : "Download as GeoJSON"}
               </button>
               <span
                 id="dataset-map-geojson-download-tip"
@@ -729,6 +744,11 @@ function DatasetMapPreview({
                   ? `Download the current map with selected year ${mapYear} as GeoJSON, with all table properties.`
                   : "Download the current map as GeoJSON, with all table properties."}
               </span>
+              {exportError && (
+                <p className="dataset-map-preview__download-error" role="alert">
+                  {exportError}
+                </p>
+              )}
             </div>
           </aside>
         </div>

--- a/src/components/partials/ExportDataModal.jsx
+++ b/src/components/partials/ExportDataModal.jsx
@@ -5,6 +5,7 @@ import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { faClone } from "@fortawesome/free-regular-svg-icons";
 import { supportsTabularGeojsonExport } from "../../utils/datasetMapPreview";
 import { resolveDefaultSelectedYears } from "../../utils/bulkDownloadApi";
+import { ExportLoadingMask, useExportFileDownload } from "./ExportLoadingMask";
 
 const formats = {
   csv: {
@@ -125,18 +126,12 @@ const toAbsoluteExportUrl = (url) => {
   return url;
 };
 
-/** Start file download without opening a new tab (avoids a blank window from window.open). */
-const triggerExportFileDownload = (url) => {
-  if (!url || url === "#") {
-    return;
+const fallbackExportFilename = (table, format, geojsonYearCount = 0) => {
+  const base = table || "export";
+  if (format === "geojson" && geojsonYearCount > 1) {
+    return `${base}.zip`;
   }
-  const link = document.createElement("a");
-  link.href = /^https?:\/\//i.test(url) ? url : toAbsoluteExportUrl(url);
-  link.rel = "noopener noreferrer";
-  link.style.display = "none";
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  return `${base}${formats[format]?.extension || ""}`;
 };
 
 const getDownloadFormatOptions = (database, table) => {
@@ -187,6 +182,7 @@ function ExportDataModal({
   const [apiCopyStatus, setApiCopyStatus] = useState("");
   const [justCopiedEndpoint, setJustCopiedEndpoint] = useState(false);
   const [geojsonDownloadError, setGeojsonDownloadError] = useState("");
+  const { isExporting, exportError, runExportDownload, clearExportError } = useExportFileDownload();
   const copyEndpointFeedbackTimerRef = useRef(null);
 
   const allowsTabularGeojson = supportsTabularGeojsonExport(table);
@@ -347,7 +343,20 @@ function ExportDataModal({
     }
   };
 
-  const handleDownloadSubmit = () => {
+  useEffect(() => {
+    if (!isOpen) {
+      clearExportError();
+    }
+  }, [isOpen, clearExportError]);
+
+  const handleClose = () => {
+    if (isExporting) return;
+    onClose();
+  };
+
+  const handleDownloadSubmit = async () => {
+    if (isExporting) return;
+
     if (exportTarget === "metadata") {
       downloadMetadata(metadata, title);
       return;
@@ -366,8 +375,15 @@ function ExportDataModal({
     }
 
     setGeojsonDownloadError("");
+    clearExportError();
     const downloadUrl = getConfiguredExportUrl(effectiveDownloadScope);
-    triggerExportFileDownload(downloadUrl);
+    const absoluteUrl = /^https?:\/\//i.test(downloadUrl)
+      ? downloadUrl
+      : toAbsoluteExportUrl(downloadUrl);
+    await runExportDownload(
+      absoluteUrl,
+      fallbackExportFilename(table, downloadFormat, geojsonYears.length),
+    );
   };
 
   const geojsonDownloadDisabled =
@@ -383,17 +399,25 @@ function ExportDataModal({
   }
 
   return (
-    <div className="download-modal-overlay" role="presentation" onClick={onClose}>
+    <div className="download-modal-overlay" role="presentation" onClick={handleClose}>
       <div
         className="download-modal"
         role="dialog"
         aria-modal="true"
         aria-label="Export data"
+        aria-busy={isExporting}
         onClick={(e) => e.stopPropagation()}
       >
+        <ExportLoadingMask active={isExporting} />
         <div className="download-modal-header">
           <h3>Export data</h3>
-          <button type="button" className="close-button" onClick={onClose} aria-label="Close export dialog">
+          <button
+            type="button"
+            className="close-button"
+            onClick={handleClose}
+            disabled={isExporting}
+            aria-label="Close export dialog"
+          >
             <FontAwesomeIcon icon={faXmark} aria-hidden />
           </button>
         </div>
@@ -602,6 +626,12 @@ function ExportDataModal({
               </>
             )}
 
+            {exportError && (
+              <p className="download-option-note download-geojson-error" role="alert">
+                {exportError}
+              </p>
+            )}
+
             {exportTarget === "data" && (
               <p className="download-modal-api-more download-modal-api-more--bottom">
                 <a
@@ -615,7 +645,7 @@ function ExportDataModal({
           </>
         </div>
         <div className="download-modal-footer">
-          <button type="button" className="button" onClick={onClose}>
+          <button type="button" className="button" onClick={handleClose} disabled={isExporting}>
             Close
           </button>
           <button
@@ -625,6 +655,7 @@ function ExportDataModal({
             }`}
             onClick={handleDownloadSubmit}
             disabled={
+              isExporting ||
               (downloadDestination === "file" && geojsonDownloadDisabled) ||
               (exportTarget === "metadata" && (!metadata || (Array.isArray(metadata) && metadata.length === 0)))
             }
@@ -635,7 +666,9 @@ function ExportDataModal({
                 ? justCopiedEndpoint
                   ? "Copied!"
                   : "Copy endpoint"
-                : "Download"}
+                : isExporting
+                  ? "Preparing…"
+                  : "Download"}
           </button>
         </div>
       </div>

--- a/src/components/partials/ExportLoadingMask.jsx
+++ b/src/components/partials/ExportLoadingMask.jsx
@@ -1,0 +1,67 @@
+import { useCallback, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import MoonLoader from "react-spinners/MoonLoader";
+import { fetchAndDownloadFile } from "../../utils/bulkDownloadApi";
+
+export const EXPORT_DOWNLOAD_FAILED = "Please try again later.";
+
+/**
+ * In-container loading mask for dataset export flows.
+ * Parent must be `position: relative` (e.g. the export modal).
+ */
+export function ExportLoadingMask({ active }) {
+  if (!active) return null;
+
+  return (
+    <div className="export-loading-mask" role="status" aria-live="polite" aria-label="Preparing download">
+      <MoonLoader size={36} color="#767676" />
+      <span>Preparing download…</span>
+    </div>
+  );
+}
+
+ExportLoadingMask.propTypes = {
+  active: PropTypes.bool,
+};
+
+/**
+ * Shared export download state + fetch helper for modal and map actions.
+ */
+export function useExportFileDownload() {
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState("");
+  const exportingRef = useRef(false);
+
+  const clearExportError = useCallback(() => {
+    setExportError("");
+  }, []);
+
+  const runExportDownload = useCallback(async (url, fallbackFilename) => {
+    if (exportingRef.current) return false;
+    if (!url || url === "#") {
+      setExportError(EXPORT_DOWNLOAD_FAILED);
+      return false;
+    }
+
+    exportingRef.current = true;
+    setExportError("");
+    setIsExporting(true);
+    try {
+      await fetchAndDownloadFile(url, fallbackFilename);
+      return true;
+    } catch {
+      setExportError(EXPORT_DOWNLOAD_FAILED);
+      return false;
+    } finally {
+      exportingRef.current = false;
+      setIsExporting(false);
+    }
+  }, []);
+
+  return {
+    isExporting,
+    exportError,
+    runExportDownload,
+    clearExportError,
+  };
+}

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -300,13 +300,15 @@ class DataViewerClass extends React.Component {
         // Dropdown uses name columns (muni_name / municipal); map joins use muni_id separately.
         // Tract tables still map via resolveMapGeographyColumn inside DatasetMapPreview;
         // setting geographyColumn here without selectedGeographies would empty the table.
-        let selectedGeographies;
-        let availableGeographies;
-        let geographyColumn;
-        const geographyType = detectDatasetGeographyType(dataset.table_name);
+        // Native census tract boundary tables (gisdata shape) enable map view without a filter dropdown.
+        let selectedGeographies = [];
+        let availableGeographies = [];
+        let geographyColumn = null;
+        const geographyType = detectDatasetGeographyType(
+          dataset.table_name,
+          dataset.geography,
+        );
         if (dataset.schemaname === "tabular") {
-          geographyColumn = null;
-          availableGeographies = [];
           if (geographyType === "municipal") {
             geographyColumn = resolveTableGeographyColumn(tableResults[0]);
             if (geographyColumn) {

--- a/src/utils/bulkDownloadApi.js
+++ b/src/utils/bulkDownloadApi.js
@@ -94,7 +94,7 @@ function groupBundleListFromRows(bundleRows, tableRows) {
       id: bundleId,
       title: row.title,
       description: row.description,
-      geographyType: row.geography_type || row.geographyType || "municipality",
+      geographyType: row.geographyType || "municipality",
       sortOrder: Number(row.sortOrder ?? row.sort_order ?? 0),
       tables: tablesByBundleId[bundleId] || [],
     };
@@ -134,8 +134,6 @@ async function fetchBundleListApiRows(bundleId) {
   ]);
 
   let bundleRows = bundleData.rows || [];
-  // Filter active client-side. The API `filters=active:Y` path can return stale
-  // cached metadata (e.g. an outdated housing title).
   if (!bundleId) {
     bundleRows = bundleRows.filter((row) => String(row.active ?? "Y").toUpperCase() === "Y");
   }
@@ -242,11 +240,7 @@ export async function requestBulkExport({
   }
 
   const blob = await response.blob();
-  const disposition = response.headers.get("Content-Disposition") || "";
-  const filenameMatch = disposition.match(/filename="?([^";\n]+)"?/);
-  const filename =
-    filenameMatch?.[1] ||
-    buildBulkDownloadFilename(municipalities, bundleSlug, defaultExtension);
+  const filename = buildBulkDownloadFilename(municipalities, bundleSlug, defaultExtension);
 
   return { blob, filename };
 }
@@ -261,4 +255,17 @@ export function downloadBlob(blob, filename) {
   link.click();
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
+}
+
+/**
+ * Fetch a file URL and save it under `filename` (usually the table name + extension).
+ */
+export async function fetchAndDownloadFile(url, filename = "download") {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Download failed (${response.status})`);
+  }
+  const blob = await response.blob();
+  downloadBlob(blob, filename);
+  return filename;
 }

--- a/src/utils/datasetMapPreview.js
+++ b/src/utils/datasetMapPreview.js
@@ -35,12 +35,33 @@ const CHOROPLETH_COLORS = ["#EDF8FB", "#B2E2E2", "#66C2A4", "#2CA25F", "#006D2C"
 
 /**
  * @param {string} tableName
+ * @param {string|null|undefined} [geographyHint] Optional `_data_browser.geography` value
  * @returns {"municipal"|"census_tracts"|null}
  */
-export function detectDatasetGeographyType(tableName) {
-  if (!tableName || typeof tableName !== "string") return null;
+export function detectDatasetGeographyType(tableName, geographyHint = null) {
+  if (isNativeCensusTractBoundaryTable(tableName)) {
+    return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
+  }
+  if (!tableName || typeof tableName !== "string") {
+    const hint = String(geographyHint || "").toLowerCase();
+    if (hint.includes("census_tract") || hint.includes("census tract")) {
+      return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
+    }
+    if (hint.includes("municipal")) {
+      return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
+    }
+    return null;
+  }
   if (tableName.endsWith("_m")) return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
   if (tableName.endsWith("_ct")) return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
+
+  const hint = String(geographyHint || "").toLowerCase();
+  if (hint.includes("census_tract") || hint.includes("census tract")) {
+    return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
+  }
+  if (hint.includes("municipal")) {
+    return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
+  }
   return null;
 }
 
@@ -56,8 +77,10 @@ export function isMapPreviewSupported(geographyType) {
 }
 
 /** municipal and census tract tables can export geojson via the export API
+ * Native tract boundary tables (shape column) use standard geospatial export instead.
  */
 export function supportsTabularGeojsonExport(tableName) {
+  if (isNativeCensusTractBoundaryTable(tableName)) return false;
   return isMapPreviewSupported(detectDatasetGeographyType(tableName));
 }
 
@@ -816,7 +839,154 @@ export const GIS_BOUNDARY_LAYERS = {
   },
 };
 
+/** a temporary fix for census tract boundary datasets that already store polygons in a `shape` column
+ * Census tract boundary datasets that already store polygons in a `shape` column
+ * Map preview reads shape directly instead of joining.
+ */
+export const NATIVE_CENSUS_TRACT_BOUNDARY_TABLES = {
+  census2010_tracts_poly: {
+    database: "gisdata",
+    schema: "mapc",
+    table: "census2010_tracts_poly",
+    joinKey: "ct10_id",
+    idColumn: "ct10_id",
+    attributeColumns: ["ct10_id", "area_sqft", "area_acres"],
+    boundaryLabel: "2010 Census tracts",
+  },
+  census2020_tracts_poly: {
+    database: "gisdata",
+    schema: "mapc",
+    table: "census2020_tracts_poly",
+    joinKey: "ct20_id",
+    idColumn: "GEOID",
+    attributeColumns: ["GEOID", "name", "namelsad", "aland", "awater", "tractce"],
+    boundaryLabel: "2020 Census tracts",
+  },
+};
+
+/**
+ * Quote mixed-case Postgres identifiers (e.g. GEOID) so they are not folded to lowercase.
+ * @param {string} column
+ * @returns {string}
+ */
+function quoteSqlIdentifier(column) {
+  if (!column || typeof column !== "string") return column;
+  if (column.includes("(") || column.includes('"')) return column;
+  if (column !== column.toLowerCase()) return `"${column.replace(/"/g, '""')}"`;
+  return column;
+}
+
+/**
+ * Read a row value when the API may return GEOID or geoid.
+ * @param {object} row
+ * @param {string} column
+ */
+function rowValue(row, column) {
+  if (!row || column == null) return undefined;
+  if (row[column] !== undefined) return row[column];
+  const lower = String(column).toLowerCase();
+  if (row[lower] !== undefined) return row[lower];
+  const match = Object.keys(row).find((key) => key.toLowerCase() === lower);
+  return match != null ? row[match] : undefined;
+}
+
+/**
+ * @param {string} tableName
+ * @returns {boolean}
+ */
+export function isNativeCensusTractBoundaryTable(tableName) {
+  return Boolean(NATIVE_CENSUS_TRACT_BOUNDARY_TABLES[tableName]);
+}
+
 const gisBoundaryCache = new Map();
+const nativeTractBoundaryCache = new Map();
+
+/**
+ * Load a native census-tract boundary table (shape column) as WGS84 GeoJSON.
+ * @param {{ database?: string, schema?: string, table: string }} params
+ */
+export async function fetchNativeCensusTractBoundaryGeojson(params = {}) {
+  const { table } = params;
+  const config = NATIVE_CENSUS_TRACT_BOUNDARY_TABLES[table];
+  if (!config) {
+    throw new Error(`Table "${table}" is not a native census tract boundary table`);
+  }
+
+  const database = params.database || config.database;
+  const schema = params.schema || config.schema;
+  const cacheKey = `${database}.${schema}.${table}`;
+  if (nativeTractBoundaryCache.has(cacheKey)) {
+    return nativeTractBoundaryCache.get(cacheKey);
+  }
+
+  const pending = (async () => {
+    const columns = [
+      ...config.attributeColumns.map(quoteSqlIdentifier),
+      "sde.ST_AsText(shape) as geom_wkt",
+    ].join(",");
+    const search = new URLSearchParams({
+      token: import.meta.env.VITE_MAPC_API_TOKEN,
+      database,
+      schema,
+      table,
+      columns,
+      orderByColumn: quoteSqlIdentifier(config.idColumn),
+      orderByDirection: "ASC",
+      limit: "5000",
+    });
+
+    const response = await fetch(`/api?${search.toString()}`);
+    if (!response.ok) {
+      throw new Error(`Native tract boundary HTTP ${response.status}`);
+    }
+    const payload = await response.json();
+    const rows = payload.rows || [];
+
+    const features = rows
+      .map((row) => {
+        const geometry = parseWktPolygon(rowValue(row, "geom_wkt"));
+        if (!geometry) return null;
+        const id = rowValue(row, config.idColumn);
+        const properties = {
+          __joinKey: config.joinKey,
+          __mapLabel: String(id ?? rowValue(row, "name") ?? rowValue(row, "namelsad") ?? "Census tract"),
+        };
+        config.attributeColumns.forEach((col) => {
+          const value = rowValue(row, col);
+          if (value != null) properties[col] = value;
+        });
+        // Normalize so details panel can label 2020 boundaries via ct20_id.
+        if (config.joinKey === "ct20_id" && properties.GEOID != null && properties.ct20_id == null) {
+          properties.ct20_id = properties.GEOID;
+        }
+        return {
+          type: "Feature",
+          id: id != null ? String(id) : undefined,
+          properties,
+          geometry: reprojectGeometry(geometry),
+        };
+      })
+      .filter(Boolean);
+
+    if (!features.length) {
+      throw new Error(`No geometries returned for ${schema}.${table}`);
+    }
+
+    return {
+      featureCollection: { type: "FeatureCollection", features },
+      joinKey: config.joinKey,
+      boundaryLabel: config.boundaryLabel,
+    };
+  })();
+
+  nativeTractBoundaryCache.set(cacheKey, pending);
+  try {
+    return await pending;
+  } catch (err) {
+    nativeTractBoundaryCache.delete(cacheKey);
+    throw err;
+  }
+}
 
 /**
  * Parse a simple WKT POLYGON / MULTIPOLYGON into GeoJSON geometry coordinates.


### PR DESCRIPTION
- enable map preview for census tract boundary tables that already have a shape column (`census2010_tracts_poly` / `census2020_tracts_poly`)
- Quote mixed-case columns like "GEOID" so Postgres does not fold them to lowercase
- add a loading mask when users export data
