### PR TITLE
Pass mix() weights with % unit to fix Sass function-units deprecation

### DIFF
--- a/src/assets/styles/partials/_mixins.scss
+++ b/src/assets/styles/partials/_mixins.scss
@@ -18,8 +18,8 @@
 }
 
 @mixin partialGradient($piece, $total) {
-  $finish: mix($color_brand-secondary, $color_brand-primary, ($piece / $total) * 100);
-  $start: mix($color_brand-secondary, $color_brand-primary, (($piece - 1) / $total) * 100);
+  $finish: mix($color_brand-secondary, $color_brand-primary, ($piece / $total) * 100%);
+  $start: mix($color_brand-secondary, $color_brand-primary, (($piece - 1) / $total) * 100%);
 
   background: linear-gradient(to right, $start, $finish);
 }

--- a/src/assets/styles/partials/_vars.scss
+++ b/src/assets/styles/partials/_vars.scss
@@ -1,17 +1,17 @@
 $color_brand-primary: #6FC68E;
 $color_brand-secondary: #44aD89;
-$color_brand-secondary--dark: mix(black, $color_brand-secondary, 15);
+$color_brand-secondary--dark: mix(black, $color_brand-secondary, 15%);
 
 $color_bg-light: #FFFFFF;
 $color_bg-medium: #F5F5F5;
 $color_bg-dark: #1F4E46;
-$color_bg-medium--light: mix(white, $color_bg-medium, 50);
+$color_bg-medium--light: mix(white, $color_bg-medium, 50%);
 
 $color_font-light: #FFFFFF;
 $color_font-medium: #95989A;
 $color_font-dark: #1F4E46;
-$color_font-medium--dark: mix(black, $color_font-medium, 25);
-$color_font-dark--brand: mix($color_brand-primary, $color_font-dark, 25);
+$color_font-medium--dark: mix(black, $color_font-medium, 25%);
+$color_font-dark--brand: mix($color_brand-primary, $color_font-dark, 25%);
 
 $font_family-primary: 'skolar-sans-latin', Helvetica, sans-serif;
 $font_family-secondary: 'Montserrat';


### PR DESCRIPTION
This PR proposes passing the `mix()` weight arguments in your Sass partials with an explicit `%` unit so `yarn build` stops emitting the `function-units` deprecation warnings. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/246. You can sign in with your GitHub ID to claim ownership of the project.

## What this changes and why

A `yarn build` on `main` today prints ten `function-units` deprecation warnings from Dart Sass. Every one comes from a `mix()` call whose weight is passed as a unitless number, for example in `src/assets/styles/partials/_vars.scss`:

`$color_brand-secondary--dark: mix(black, $color_brand-secondary, 15);`

Dart Sass reports: `DEPRECATION WARNING [function-units]: $weight: Passing a number without unit % (15) is deprecated. To preserve current behavior: $weight * 1%`. These warnings become hard errors in Dart Sass 3.0, at which point the build breaks. The fix is the exact behavior-preserving form Sass documents: give each weight a `%` unit (`15` becomes `15%`, and the computed weights in `partialGradient()` become `... * 100%`). Sass already interprets a unitless weight as that percentage, so this is a no-op for the produced colors.

Reproduce on the current default branch: `yarn build 2>&1 | grep -c function-units` prints `10`. After this change the same command prints `0`.

Verification: I compiled the stylesheet before and after the change and the emitted CSS is byte-for-byte identical (both 174,829 bytes, sha1 `301f2cd8d51cea992b904a7a77c51b1985b10f57`), so no rendered color or style changes. The build still exits `0`, and the change is limited to `_vars.scss` and `_mixins.scss`. The other, unrelated Sass deprecations in the build (`slash-div`, `@import`, global built-ins) are separate migrations with different semantics and are intentionally left out of this PR.

## How this was managed

This work is tracked as a story on a live agile board that was imported from this repository's history (174 pull requests): the story for this change is at https://eastagiletracker.com/projects/246/stories/145336 and the full board is at https://eastagiletracker.com/projects/246.

![board](https://raw.githubusercontent.com/eastagiletracker/datacommon-react/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
