### PR TITLE
Hide muni finance subregion tab

### DIFF
--- a/src/components/SubregionProfilesView.jsx
+++ b/src/components/SubregionProfilesView.jsx
@@ -156,7 +156,10 @@ const chunkArray = (array, size) => {
 const SubregionProfilesView = () => {
   const dispatch = useDispatch();
   const { subregionId, tab } = useParams();
-  const availableTabs = tabs;
+
+  // muni-finance not available at subregion level
+  const availableTabs = tabs.filter(tab => tab.value !== 'municipal-finance');
+
   const sanitizeTab = (value) =>
     value ? value : "demographics";
   const [activeTab, setActiveTab] = useState(sanitizeTab(tab));

--- a/src/components/field/DownloadAllChartsButton.jsx
+++ b/src/components/field/DownloadAllChartsButton.jsx
@@ -169,7 +169,9 @@ export default function DownloadAllChartsButton({ muni, datatype, displayName })
 
       Object.values(charts).forEach((category) => {
         Object.values(category).forEach((chartInfo) => {
-          Object.keys(chartInfo.tables).forEach((tableName) => {
+          // check that chartInfo.tables exists. Muni-finance map didn't have it. 
+          chartInfo.tables && Object.keys(chartInfo.tables).forEach((tableName) => {
+            console.log('in table:', tableName)
             let data;
             switch (datatype) {
               case 'subregion':

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -134,10 +134,10 @@ const router = createBrowserRouter([
         path: "/profile/subregion/:subregionId/:tab?",
         element: <SubregionProfileRoute tabOptions={tabOptions} />
       },
-      {
-        path: "/profile/rpa/:rpaId/:tab?",
-        element: <RPAProfileRoute tabOptions={tabOptions} />
-      },
+      // {
+      //   path: "/profile/rpa/:rpaId/:tab?",
+      //   element: <RPAProfileRoute tabOptions={tabOptions} />
+      // },
       {
         path: "gallery",
         children: [

--- a/src/pages/CommunitySelectorPage.jsx
+++ b/src/pages/CommunitySelectorPage.jsx
@@ -99,7 +99,7 @@ const CommunitySelectorPage = () => {
   const handleMunicipalitySelect = useCallback((municipality) => {
     const formattedMuni = municipality.toLowerCase().replace(/\s+/g, '-');
     dispatch(fillPoly(formattedMuni));
-    navigate(`/profile/${formattedMuni}`);
+    navigate(`/profile/${formattedMuni}/demographics`);
   }, [dispatch, navigate]);
 
   return (


### PR DESCRIPTION
Hides the muni-finance tab when viewing a subregion community profile. 

Fixes history issue with community profiles causing back button behavior to be incorrect. 

Fixes the 'download all charts' button which was broken. 