### PR TITLE
handle edge case for municipal table, add compass to map/ add MOE to details / fix boundary map overlay issue

### DIFF
--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -2062,10 +2062,10 @@
     border-radius: 6px;
     background-color: #fff;
     color: $color_font-dark;
-    font-size: $font_size-xsmall;
+    font-size: 0.95rem;
     font-weight: 500;
     line-height: 1.35;
-    padding: 10px 36px 10px 12px;
+    padding: 11px 36px 11px 12px;
     cursor: pointer;
     transition: border-color 0.14s, background-color 0.14s, box-shadow 0.14s;
     -webkit-appearance: none;
@@ -2142,6 +2142,61 @@
     min-height: 520px;
     background: #e8eef0;
     min-width: 0;
+
+    // Keep Mapbox zoom/compass above map chrome.
+    .mapboxgl-ctrl-bottom-right {
+      z-index: 4;
+      bottom: 8px;
+      right: 8px;
+    }
+
+    .mapboxgl-ctrl-group {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    }
+
+    .mapboxgl-ctrl-compass {
+      display: block !important;
+    }
+  }
+
+  .dataset-map-preview__map-controls {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 4;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+  }
+
+  .dataset-map-preview__north-arrow {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    width: 36px;
+    padding: 6px 4px 4px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid rgba($color_font-medium, 0.22);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+    pointer-events: none;
+  }
+
+  .dataset-map-preview__north-arrow-pointer {
+    width: 0;
+    height: 0;
+    border-left: 7px solid transparent;
+    border-right: 7px solid transparent;
+    border-bottom: 14px solid #c23b2e;
+  }
+
+  .dataset-map-preview__north-arrow-label {
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    color: $color_font-dark;
   }
 
   .dataset-map-preview__detail {
@@ -2257,7 +2312,7 @@
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
   }
 
   .dataset-map-preview__detail-row {
@@ -2277,22 +2332,70 @@
     dd {
       margin: 0;
       font-size: 0.95rem;
+      font-weight: 600;
       color: $color_font-dark;
       word-break: break-word;
     }
 
-    &--emphasis dd {
-      font-size: 1.15rem;
-      font-weight: 700;
-      color: $color_font-dark;
+    &--inline {
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+
+      dt {
+        flex: 0 0 auto;
+        text-transform: none;
+        letter-spacing: 0;
+        font-size: 12px;
+        font-weight: 500;
+        color: $color_font-medium--dark;
+      }
+
+      dd {
+        flex: 1 1 auto;
+        text-align: right;
+        font-size: 13px;
+        font-weight: 600;
+      }
     }
   }
 
+  .dataset-map-preview__detail-metric {
+    margin-top: 4px;
+    padding-top: 12px;
+    border-top: 1px solid rgba($color_font-medium, 0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .dataset-map-preview__detail-metric-label {
+    margin: 0;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.35;
+    color: $color_font-medium--dark;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
+  .dataset-map-preview__detail-metric-value {
+    margin: 0;
+    font-size: 1.35rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: $color_font-dark;
+    word-break: break-word;
+  }
+
+  .dataset-map-preview__detail-metric-moe {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: $color_font-medium--dark;
+  }
+
   .dataset-map-preview__layer-toggles {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    z-index: 3;
     display: flex;
     flex-direction: column;
     gap: 6px;

--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -666,6 +666,7 @@ function DatasetHeader({
   onViewModeChange,
   mapPreviewSupported = false,
   mapVariable = null,
+  geographyType = null,
 }) {
   const location = useLocation();
   const isEmbedView = new URLSearchParams(location.search).get("embed") === "1";
@@ -961,6 +962,7 @@ function DatasetHeader({
         availableGeographies={availableGeographies}
         geographyColumn={geographyColumn}
         availableYears={availableYears}
+        geographyType={geographyType}
       />
       <EmbedTableModal
         isOpen={embedModalOpen}
@@ -1018,6 +1020,7 @@ DatasetHeader.propTypes = {
   onViewModeChange: PropTypes.func,
   mapPreviewSupported: PropTypes.bool,
   mapVariable: PropTypes.string,
+  geographyType: PropTypes.oneOf(["municipal", "census_tracts", "block_groups"]),
 };
 
 export default DatasetHeader;

--- a/src/components/partials/DatasetMapPreview.jsx
+++ b/src/components/partials/DatasetMapPreview.jsx
@@ -18,6 +18,7 @@ import {
   filterRowsForMapPreview,
   formatMapValue,
   getColumnUnit,
+  getMarginColumnForBase,
   getMappableColumns,
   isNativeCensusTractBoundaryTable,
   resolveMapGeographyColumn,
@@ -35,6 +36,17 @@ const MUNI_LINE_LAYER_ID = "dataset-map-preview-muni-line";
 const MAPC_SOURCE_ID = "dataset-map-preview-mapc";
 const MAPC_LINE_LAYER_ID = "dataset-map-preview-mapc-line";
 const EMPTY_FC = { type: "FeatureCollection", features: [] };
+
+function bringOverlayLayersToFront(map) {
+  if (!map) return;
+  // Keep reference overlays above the choropleth fill/outline so toggles are visible.
+  if (map.getLayer(MUNI_LINE_LAYER_ID)) {
+    map.moveLayer(MUNI_LINE_LAYER_ID);
+  }
+  if (map.getLayer(MAPC_LINE_LAYER_ID)) {
+    map.moveLayer(MAPC_LINE_LAYER_ID);
+  }
+}
 
 function DatasetMapPreview({
   rows = [],
@@ -127,6 +139,11 @@ function DatasetMapPreview({
     return getColumnUnit(column);
   }, [activeVariable, columnKeys, mappableColumns]);
 
+  const marginColumn = useMemo(
+    () => getMarginColumnForBase(columnKeys, activeVariable),
+    [columnKeys, activeVariable],
+  );
+
   useEffect(() => {
     if (!activeVariable) return;
     if (mapVariable !== activeVariable) {
@@ -142,15 +159,22 @@ function DatasetMapPreview({
     const loadOverlays = async () => {
       setOverlaysLoading(true);
       try {
-        const [muniFc, mapcFc] = await Promise.all([
+        // Load independently so one failure (e.g. unauthorized MAPC table) does not block both.
+        const [muniResult, mapcResult] = await Promise.allSettled([
           fetchGisBoundaryLayer("municipal"),
           fetchGisBoundaryLayer("mapcRegion"),
         ]);
         if (cancelled) return;
-        setMuniOverlayGeojson(muniFc);
-        setMapcOverlayGeojson(mapcFc);
-      } catch (err) {
-        console.error("Failed to load map overlay boundaries from gisdata:", err);
+        if (muniResult.status === "fulfilled") {
+          setMuniOverlayGeojson(muniResult.value);
+        } else {
+          console.error("Failed to load municipal overlay boundaries:", muniResult.reason);
+        }
+        if (mapcResult.status === "fulfilled") {
+          setMapcOverlayGeojson(mapcResult.value);
+        } else {
+          console.error("Failed to load MAPC region overlay boundaries:", mapcResult.reason);
+        }
       } finally {
         if (!cancelled) {
           setOverlaysLoading(false);
@@ -293,6 +317,35 @@ function DatasetMapPreview({
     apiBoundaryGeojson,
   ]);
 
+  const moeByGeography = useMemo(() => {
+    if (!marginColumn) return null;
+
+    if (apiBoundaryGeojson?.features?.length) {
+      const fromFeatures = buildValueByGeographyFromFeatures({
+        features: apiBoundaryGeojson.features,
+        valueColumn: marginColumn,
+        geographyType,
+      });
+      if (fromFeatures.size) return fromFeatures;
+    }
+
+    if (!geographyColumn) return null;
+    return buildValueByGeography({
+      rows: filteredRows,
+      geographyColumn,
+      valueColumn: marginColumn,
+      yearColumn: queryYearColumn,
+      geographyType,
+    });
+  }, [
+    marginColumn,
+    apiBoundaryGeojson,
+    geographyType,
+    geographyColumn,
+    filteredRows,
+    queryYearColumn,
+  ]);
+
   const { colorForValue, legend, binningDescription } = useMemo(
     () => buildChoroplethScale([...valueByGeography.values()], { unit: activeVariableUnit }),
     [valueByGeography, activeVariableUnit],
@@ -303,10 +356,11 @@ function DatasetMapPreview({
     return enrichBoundariesWithValues({
       baseGeojson,
       valueByGeography,
+      moeByGeography,
       geographyType,
       colorForValue,
     });
-  }, [baseGeojson, valueByGeography, geographyType, colorForValue]);
+  }, [baseGeojson, valueByGeography, moeByGeography, geographyType, colorForValue]);
 
   useEffect(() => {
     if (!mapContainerRef.current || mapRef.current) return undefined;
@@ -314,14 +368,16 @@ function DatasetMapPreview({
     const map = new mapboxgl.Map({
       container: mapContainerRef.current,
       style: MAP_CONFIG.style,
-      dragRotate: false,
+      dragRotate: true,
+      touchPitch: false,
+      pitchWithRotate: false,
       bounds: MAP_CONFIG.bounds,
       fitBoundsOptions: { padding: { top: 24, bottom: 24, left: 24, right: 24 }, animate: false },
     });
 
     map.addControl(
       new mapboxgl.NavigationControl({
-        showCompass: false,
+        showCompass: true,
         showZoom: true,
         visualizePitch: false,
       }),
@@ -378,8 +434,8 @@ function DatasetMapPreview({
         layout: { visibility: "none" },
         paint: {
           "line-color": "#094A72",
-          "line-width": 0.9,
-          "line-opacity": 0.9,
+          "line-width": 1.6,
+          "line-opacity": 1,
         },
       });
 
@@ -393,11 +449,13 @@ function DatasetMapPreview({
         source: MAPC_SOURCE_ID,
         layout: { visibility: "none" },
         paint: {
-          "line-color": "#ED948D",
-          "line-width": 2,
+          "line-color": "#C23B2E",
+          "line-width": 2.5,
           "line-opacity": 1,
         },
       });
+
+      bringOverlayLayersToFront(map);
 
       map.on("mouseenter", FILL_LAYER_ID, () => {
         map.getCanvas().style.cursor = "pointer";
@@ -428,6 +486,7 @@ function DatasetMapPreview({
     if (source) {
       source.setData(muniOverlayGeojson || EMPTY_FC);
     }
+    bringOverlayLayersToFront(map);
   }, [muniOverlayGeojson, mapReady]);
 
   useEffect(() => {
@@ -437,6 +496,7 @@ function DatasetMapPreview({
     if (source) {
       source.setData(mapcOverlayGeojson || EMPTY_FC);
     }
+    bringOverlayLayersToFront(map);
   }, [mapcOverlayGeojson, mapReady]);
 
   useEffect(() => {
@@ -445,6 +505,7 @@ function DatasetMapPreview({
     const visibility = showMunicipalLayer ? "visible" : "none";
     if (map.getLayer(MUNI_LINE_LAYER_ID)) {
       map.setLayoutProperty(MUNI_LINE_LAYER_ID, "visibility", visibility);
+      if (showMunicipalLayer) bringOverlayLayersToFront(map);
     }
   }, [showMunicipalLayer, mapReady]);
 
@@ -454,6 +515,7 @@ function DatasetMapPreview({
     const visibility = showMapcRegionLayer ? "visible" : "none";
     if (map.getLayer(MAPC_LINE_LAYER_ID)) {
       map.setLayoutProperty(MAPC_LINE_LAYER_ID, "visibility", visibility);
+      if (showMapcRegionLayer) bringOverlayLayersToFront(map);
     }
   }, [showMapcRegionLayer, mapReady]);
 
@@ -471,6 +533,8 @@ function DatasetMapPreview({
         geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts ? 0.4 : 0.7,
       );
     }
+    // Choropleth updates can reshuffle paint order; keep overlays on top.
+    bringOverlayLayersToFront(map);
   }, [paintedGeojson, mapReady, geographyType]);
 
   useEffect(() => {
@@ -560,13 +624,24 @@ function DatasetMapPreview({
       }
     }
 
+    let marginOfError = null;
+    if (marginColumn) {
+      const rawMoe =
+        props.__mapMoe ??
+        props[marginColumn] ??
+        Object.entries(props).find(([key]) => key.toLowerCase() === marginColumn.toLowerCase())?.[1];
+      const moeNum = rawMoe == null || rawMoe === "" ? null : Number(rawMoe);
+      marginOfError = Number.isFinite(moeNum) ? moeNum : null;
+    }
+
     return {
       label,
       value: Number.isFinite(value) ? value : null,
+      marginOfError,
       year: mapYear != null ? String(mapYear) : null,
       tractBoundary,
     };
-  }, [selectedFeature, mapYear, geographyType, geometryJoinKey]);
+  }, [selectedFeature, mapYear, geographyType, geometryJoinKey, marginColumn]);
 
   const canDownloadGeojson = Boolean(table) && !isBoundaryLoading && !isExporting;
 
@@ -643,25 +718,31 @@ function DatasetMapPreview({
         <div className="dataset-map-preview__map-body">
           <div className="dataset-map-preview__map-shell">
             <ExportLoadingMask active={isExporting} />
-            <div className="dataset-map-preview__layer-toggles" role="group" aria-label="Map overlay layers">
-              <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
-                <input
-                  type="checkbox"
-                  checked={showMunicipalLayer}
-                  disabled={overlaysLoading}
-                  onChange={(e) => setShowMunicipalLayer(e.target.checked)}
-                />
-                <span>Municipal boundaries</span>
-              </label>
-              <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
-                <input
-                  type="checkbox"
-                  checked={showMapcRegionLayer}
-                  disabled={overlaysLoading}
-                  onChange={(e) => setShowMapcRegionLayer(e.target.checked)}
-                />
-                <span>MAPC region</span>
-              </label>
+            <div className="dataset-map-preview__map-controls">
+              <div className="dataset-map-preview__north-arrow" aria-hidden="true" title="North">
+                <span className="dataset-map-preview__north-arrow-pointer" />
+                <span className="dataset-map-preview__north-arrow-label">N</span>
+              </div>
+              <div className="dataset-map-preview__layer-toggles" role="group" aria-label="Map overlay layers">
+                <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
+                  <input
+                    type="checkbox"
+                    checked={showMunicipalLayer}
+                    disabled={overlaysLoading}
+                    onChange={(e) => setShowMunicipalLayer(e.target.checked)}
+                  />
+                  <span>Municipal boundaries</span>
+                </label>
+                <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
+                  <input
+                    type="checkbox"
+                    checked={showMapcRegionLayer}
+                    disabled={overlaysLoading}
+                    onChange={(e) => setShowMapcRegionLayer(e.target.checked)}
+                  />
+                  <span>MAPC region</span>
+                </label>
+              </div>
             </div>
             <div ref={mapContainerRef} className="dataset-map-preview__map" role="img" aria-label={`Choropleth map of ${activeVariableLabel}`} />
             {isBoundaryLoading && (
@@ -736,7 +817,7 @@ function DatasetMapPreview({
                 </p>
               ) : (
                 <dl className="dataset-map-preview__detail-list">
-                  <div className="dataset-map-preview__detail-row">
+                  <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--inline">
                     <dt>
                       {geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts
                         ? "Census tract"
@@ -745,20 +826,28 @@ function DatasetMapPreview({
                     <dd>{selectedDetails.label}</dd>
                   </div>
                   {selectedDetails.year && (
-                    <div className="dataset-map-preview__detail-row">
+                    <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--inline">
                       <dt>Year</dt>
                       <dd>{selectedDetails.year}</dd>
                     </div>
                   )}
                   {selectedDetails.tractBoundary && (
-                    <div className="dataset-map-preview__detail-row">
+                    <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--inline">
                       <dt>Boundary</dt>
                       <dd>{selectedDetails.tractBoundary}</dd>
                     </div>
                   )}
-                  <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--emphasis">
-                    <dt>{activeVariableLabel}</dt>
-                    <dd>{formatMapValue(selectedDetails.value, activeVariableUnit)}</dd>
+                  <div className="dataset-map-preview__detail-metric">
+                    <dt className="dataset-map-preview__detail-metric-label">{activeVariableLabel}</dt>
+                    <dd className="dataset-map-preview__detail-metric-value">
+                      {formatMapValue(selectedDetails.value, activeVariableUnit)}
+                      {selectedDetails.marginOfError != null && (
+                        <span className="dataset-map-preview__detail-metric-moe">
+                          {" "}
+                          ± {formatMapValue(selectedDetails.marginOfError, activeVariableUnit)}
+                        </span>
+                      )}
+                    </dd>
                   </div>
                 </dl>
               )}

--- a/src/components/partials/ExportDataModal.jsx
+++ b/src/components/partials/ExportDataModal.jsx
@@ -134,9 +134,9 @@ const fallbackExportFilename = (table, format, geojsonYearCount = 0) => {
   return `${base}${formats[format]?.extension || ""}`;
 };
 
-const getDownloadFormatOptions = (database, table) => {
+const getDownloadFormatOptions = (database, table, geographyType = null) => {
   const tableIsGeospatial = database === "towndata" || database === "gisdata";
-  const allowTabularGeojson = supportsTabularGeojsonExport(table);
+  const allowTabularGeojson = supportsTabularGeojsonExport(table, geographyType);
   return Object.entries(formats).filter(([format, config]) => {
     if (format === "geojson" && allowTabularGeojson) return true;
     return config.isGeospatial === tableIsGeospatial || (!tableIsGeospatial && config.isTabular);
@@ -172,6 +172,7 @@ function ExportDataModal({
   availableGeographies = [],
   geographyColumn,
   availableYears = [],
+  geographyType = null,
 }) {
   const [exportTarget, setExportTarget] = useState("data");
   const [downloadDestination, setDownloadDestination] = useState("file");
@@ -185,8 +186,11 @@ function ExportDataModal({
   const { isExporting, exportError, runExportDownload, clearExportError } = useExportFileDownload();
   const copyEndpointFeedbackTimerRef = useRef(null);
 
-  const allowsTabularGeojson = supportsTabularGeojsonExport(table);
-  const availableDownloadFormats = useMemo(() => getDownloadFormatOptions(database, table), [database, table]);
+  const allowsTabularGeojson = supportsTabularGeojsonExport(table, geographyType);
+  const availableDownloadFormats = useMemo(
+    () => getDownloadFormatOptions(database, table, geographyType),
+    [database, table, geographyType],
+  );
   const isShapefileSelection = downloadFormat === "shapefile";
   const isTabularGeojsonSelection = downloadFormat === "geojson" && allowsTabularGeojson;
   const showGeojsonYearPicker = isTabularGeojsonSelection && Boolean(queryYearColumn) && availableYears.length > 0;
@@ -693,6 +697,7 @@ ExportDataModal.propTypes = {
   availableGeographies: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
   geographyColumn: PropTypes.string,
   availableYears: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  geographyType: PropTypes.oneOf(["municipal", "census_tracts", "block_groups"]),
 };
 
 export default ExportDataModal;

--- a/src/pages/ApiPage.jsx
+++ b/src/pages/ApiPage.jsx
@@ -1266,6 +1266,7 @@ const ApiPage = () => {
       schema: selectedDataset.schemaname || "",
       table: selectedDataset.table_name || "",
       yearcolumn: selectedDataset.yearcolumn || "",
+      geography: selectedDataset.geography || "",
     };
   }, [selectedDataset]);
 
@@ -1309,7 +1310,10 @@ const ApiPage = () => {
 
   const availableExportFormats = useMemo(() => {
     const tableIsGeospatial = datasetBasics?.database === "towndata" || datasetBasics?.database === "gisdata";
-    const allowTabularGeojson = supportsTabularGeojsonExport(datasetBasics?.table);
+    const allowTabularGeojson = supportsTabularGeojsonExport(
+      datasetBasics?.table,
+      datasetBasics?.geography,
+    );
     return Object.entries(EXPORT_FORMATS)
       .filter(([format, config]) => {
         if (format === "geojson" && allowTabularGeojson) return true;

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -627,6 +627,7 @@ class DataViewerClass extends React.Component {
             onViewModeChange={this.onViewModeChange}
             mapPreviewSupported={mapPreviewSupported}
             mapVariable={this.state.mapVariable}
+            geographyType={this.state.geographyType}
           />
           {this.state.viewMode === "map" && mapPreviewSupported ? (
             <DatasetMapPreview

--- a/src/utils/datasetMapPreview.js
+++ b/src/utils/datasetMapPreview.js
@@ -26,6 +26,7 @@ const NON_MAPPABLE_COLUMN_NAMES = new Set(
     "geometry",
     "geom",
     "logrecno",
+    "county_id",
     ...MUNICIPAL_MAP_JOIN_COLUMNS,
     ...TRACT_GEO_COLUMNS,
   ].map((name) => name.toLowerCase()),
@@ -47,7 +48,9 @@ export function detectDatasetGeographyType(tableName, geographyHint = null) {
     return geographyTypeFromHint(geographyHint);
   }
 
-  if (tableName.endsWith("_m")) return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
+  if (tableName.endsWith("_m") || tableName.endsWith("_muni")) {
+    return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
+  }
   if (tableName.endsWith("_ct")) return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
   if (
     tableName.endsWith("_bg") ||
@@ -92,10 +95,11 @@ export function isMapPreviewSupported(geographyType) {
 /**
  * Municipal, census tract, and block group tables can export GeoJSON via the export API.
  * Native tract boundary tables (shape column) use standard geospatial export instead.
+ * Pass geographyHint (e.g. `_data_browser.geography`) when the table name has no `_m`/`_ct`/`_bg` suffix.
  */
-export function supportsTabularGeojsonExport(tableName) {
+export function supportsTabularGeojsonExport(tableName, geographyHint = null) {
   if (isNativeCensusTractBoundaryTable(tableName)) return false;
-  const geographyType = detectDatasetGeographyType(tableName);
+  const geographyType = detectDatasetGeographyType(tableName, geographyHint);
   return (
     geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal ||
     geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts ||
@@ -147,6 +151,105 @@ function isNumericLike(value) {
   if (typeof value === "boolean") return false;
   const n = Number(String(value).replace(/,/g, "").trim());
   return Number.isFinite(n);
+}
+
+/**
+ * Find the margin-of-error column paired with a base estimate column.
+ * Mirrors DataViewerPage / DatasetHeader pairing (alias + common ACS suffixes).
+ * @param {Array<{name?: string, alias?: string, details?: string}>} columnKeys
+ * @param {string|null|undefined} baseColumnName
+ * @returns {string|null}
+ */
+export function getMarginColumnForBase(columnKeys = [], baseColumnName) {
+  const base = String(baseColumnName || "");
+  if (!base) return null;
+
+  const byName = new Set((columnKeys || []).map((c) => String(c?.name || "")).filter(Boolean));
+  if (!byName.has(base)) return null;
+
+  const byAlias = {};
+  (columnKeys || []).forEach((col) => {
+    const alias = String(col?.alias || "").trim().toLowerCase();
+    if (alias) byAlias[alias] = String(col?.name || "");
+  });
+
+  const normalizeAliasMetric = (text) =>
+    String(text || "")
+      .toLowerCase()
+      .replace(/\s*;\s*(estimate|margin of error)\s*$/i, "")
+      .replace(/\s*,\s*(estimate|margin of error)\s*$/i, "")
+      .trim();
+
+  const getBaseCandidates = (name) => {
+    const candidates = [];
+    const n = String(name || "");
+
+    if (n.endsWith("_mep")) {
+      candidates.push(n.slice(0, -4) + "_p");
+    } else if (/mep$/i.test(n)) {
+      candidates.push(n.slice(0, -3) + "_p");
+    }
+    if (n.endsWith("_mp")) {
+      candidates.push(n.slice(0, -3) + "_p");
+      candidates.push(n.slice(0, -3));
+    }
+    if (n.endsWith("_me")) {
+      candidates.push(n.slice(0, -3));
+    } else if (/[0-9][a-z0-9_]*me$/i.test(n)) {
+      candidates.push(n.slice(0, -2));
+    }
+    if (n.endsWith("_moe")) {
+      candidates.push(n.slice(0, -4));
+    }
+    if (
+      n.endsWith("_m") &&
+      !n.endsWith("_me") &&
+      !n.endsWith("_mp") &&
+      !n.endsWith("_moe") &&
+      !n.endsWith("_mep")
+    ) {
+      candidates.push(n.slice(0, -2));
+    }
+
+    return [...new Set(candidates.filter(Boolean))];
+  };
+
+  const pairs = [];
+  (columnKeys || []).forEach((col) => {
+    const name = String(col?.name || "");
+    if (!name) return;
+
+    const alias = String(col?.alias || "").toLowerCase();
+    const details = String(col?.details || "").toLowerCase();
+    const hintFromMetadata = alias.includes("margin of error") || details.includes("margin of error");
+    const suffixHint =
+      /(?:_mp|_me|_moe|_mep|_m)$/i.test(name) ||
+      /[0-9][a-z0-9_]*me$/i.test(name) ||
+      /[a-z0-9_]mep$/i.test(name);
+    if (!hintFromMetadata && !suffixHint) return;
+
+    let pairedBase = null;
+    if (alias.includes("margin of error")) {
+      const estimateAlias = alias.replace("margin of error", "estimate").replace(/\s+/g, " ").trim();
+      if (byAlias[estimateAlias]) {
+        pairedBase = byAlias[estimateAlias];
+      } else {
+        const normalized = normalizeAliasMetric(alias);
+        const matchedBase = (columnKeys || []).find((candidate) => {
+          const a = String(candidate?.alias || "").toLowerCase();
+          const isEstimate = /\bestimate\b/i.test(a) || (!/\bmargin of error\b/i.test(a) && !!a);
+          return isEstimate && normalizeAliasMetric(a) === normalized;
+        });
+        if (matchedBase?.name) pairedBase = matchedBase.name;
+      }
+    }
+    if (!pairedBase) {
+      pairedBase = getBaseCandidates(name).find((candidate) => byName.has(candidate)) || null;
+    }
+    if (pairedBase === base) pairs.push(name);
+  });
+
+  return pairs[0] || null;
 }
 
 /**
@@ -531,6 +634,7 @@ export function buildChoroplethScale(values = [], { unit = null } = {}) {
 export function enrichBoundariesWithValues({
   baseGeojson,
   valueByGeography,
+  moeByGeography = null,
   geographyType,
   colorForValue,
   displayNameProperty,
@@ -586,12 +690,15 @@ export function enrichBoundariesWithValues({
       const key = getFeatureKey(feature.properties);
       const value = valueByGeography.get(key);
       const hasValue = Number.isFinite(value);
+      const moeRaw = moeByGeography?.get(key);
+      const moe = Number.isFinite(moeRaw) ? moeRaw : null;
       return {
         ...feature,
         properties: {
           ...feature.properties,
           __mapKey: key,
           __mapValue: hasValue ? value : null,
+          __mapMoe: moe,
           __mapColor: colorForValue(hasValue ? value : null),
           __mapLabel: getDisplayName(feature.properties),
         },
@@ -927,10 +1034,11 @@ export const GIS_BOUNDARY_LAYERS = {
     schema: "mapc",
     table: "ma_municipalities",
   },
+  // MAPC region outline uses the static asset (same as community profiles MapBox).
+  // gisdata.mapc.mapc_municipalities_poly is not authorized for the public API token.
   mapcRegion: {
-    database: "gisdata",
-    schema: "mapc",
-    table: "mapc_municipalities_poly",
+    source: "static",
+    asset: "mapc-regions",
   },
 };
 
@@ -1165,7 +1273,7 @@ export function parseWktPolygon(wkt) {
 }
 
 /**
- * fetch mapc boundary overlays from gisdata
+ * fetch mapc boundary overlays from gisdata (municipal) or static assets (MAPC region)
  */
 export async function fetchGisBoundaryLayer(layerKey) {
   const config = GIS_BOUNDARY_LAYERS[layerKey];
@@ -1178,6 +1286,15 @@ export async function fetchGisBoundaryLayer(layerKey) {
   }
 
   const pending = (async () => {
+    if (config.source === "static" && config.asset === "mapc-regions") {
+      const module = await import("../assets/data/mapc-regions.json");
+      const fc = module.default || module;
+      if (!fc?.features?.length) {
+        throw new Error("MAPC regions asset has no features");
+      }
+      return fc;
+    }
+
     const search = new URLSearchParams({
       token: import.meta.env.VITE_MAPC_API_TOKEN,
       database: config.database,


### PR DESCRIPTION
- The SNAP Caseload Annual Summary (Municipal) database table name does not end with the _m suffix, which prevents the GeoJSON export option from being provided. Most municipal table names end with the _m suffix.
- add margin of error to map preview details
- redesign the UI layout for detail section
- add compass to map 
- fix MAPC region and municipal boundaries not showing when users toggle the button