### PR TITLE
fix boundary category map preview/improve embeded map layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,9 +6,12 @@ import Footer from './components/Footer'
 function App() {
   const location = useLocation();
   const hideSiteChrome = new URLSearchParams(location.search).get("embed") === "1";
+  const isEmbedMap =
+    hideSiteChrome &&
+    ((location.pathname || "").endsWith("/map") || location.pathname?.includes("/map"));
 
   return (
-    <section className="component App">
+    <section className={`component App${hideSiteChrome ? " App--embed" : ""}${isEmbedMap ? " App--embed-map" : ""}`}>
       {!hideSiteChrome && <Header />}
       <main>
         <Outlet />

--- a/src/assets/styles/partials/_base.scss
+++ b/src/assets/styles/partials/_base.scss
@@ -11,6 +11,48 @@ body {
     min-height: 100vh;
     background: $color_bg-light;
   }
+
+  #root > .component.App.App--embed {
+    min-height: 100%;
+    height: 100%;
+  }
+
+  #root > .component.App.App--embed-map {
+    height: 100%;
+    min-height: 100%;
+    overflow: hidden;
+
+    > main {
+      flex: 1 1 auto;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      padding-bottom: 0;
+    }
+
+    .datasets {
+      flex: 1 1 auto;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+    }
+
+    .embed-map-header-actions {
+      flex-shrink: 0;
+    }
+
+    .dataset-map-preview {
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+  }
+}
+
+html:has(.App--embed),
+html:has(.App--embed) body,
+html:has(.App--embed) #root {
+  height: 100%;
 }
 
 main {

--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -359,6 +359,26 @@
     padding-bottom: 1rem; // override the default here, smaller padding looks better
   }
 
+  // Embed map: title + kebab only (no grey source meta block).
+  .embed-map-header-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem 0.25rem;
+    background: transparent;
+  }
+
+  .embed-map-header-title {
+    margin: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: $font_size-large;
+    font-weight: 600;
+    line-height: 1.25;
+    color: $color_font-dark;
+  }
+
   // Embed (`?embed=1`): one row above the title, kebab right-aligned; h2 and details unchanged below.
   .page-header-embed-top-row {
     display: flex;
@@ -2115,13 +2135,169 @@
     min-width: 0;
   }
 
-  .dataset-map-preview__map-footer {
-    margin: 0;
-    padding: 2px 0 0;
+  &.dataset-map-preview--embed .dataset-map-preview__map-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  // Embed: map fills available height; legend scales with the map shell.
+  &.dataset-map-preview--embed {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+
+    .dataset-map-preview__map-panel {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      min-height: 0;
+      height: 100%;
+    }
+
+    .dataset-map-preview__map-body {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+
+    .dataset-map-preview__map-shell {
+      container-type: size;
+      container-name: dataset-map;
+      flex: 1 1 auto;
+      min-height: 180px;
+      height: auto;
+    }
+
+    .dataset-map-preview__map {
+      height: 100%;
+      min-height: 0;
+    }
+
+    .dataset-map-preview__legend {
+      left: clamp(6px, 2cqw, 12px);
+      bottom: clamp(6px, 2cqh, 12px);
+      max-width: min(42cqw, calc(100% - 24px));
+      max-height: min(48cqh, calc(100% - 24px));
+      overflow: auto;
+      gap: clamp(2px, 0.8cqh, 4px);
+      padding: clamp(4px, 1.4cqh, 8px) clamp(6px, 1.6cqw, 10px);
+      font-size: clamp(9px, 2.4cqh, 12px);
+      line-height: 1.3;
+      border-radius: 4px;
+    }
+
+    .dataset-map-preview__legend-title {
+      font-size: clamp(9px, 2.5cqh, 12px);
+    }
+
+    .dataset-map-preview__legend-boundary {
+      font-size: clamp(8px, 2.2cqh, 11px);
+    }
+
+    .dataset-map-preview__legend-item {
+      gap: clamp(4px, 1.2cqw, 8px);
+      font-size: clamp(9px, 2.4cqh, 12px);
+    }
+
+    .dataset-map-preview__legend-swatch {
+      width: clamp(8px, 2.2cqh, 14px);
+      height: clamp(8px, 2.2cqh, 14px);
+    }
+
+    .dataset-map-preview__map-controls {
+      top: clamp(6px, 2cqh, 12px);
+      right: clamp(6px, 2cqw, 12px);
+    }
+
+    .dataset-map-preview__metadata {
+      flex-shrink: 0;
+      font-size: clamp(10px, 1.8cqw, 12px);
+    }
+  }
+
+  .dataset-map-preview__hover-tooltip {
     font-size: 12px;
-    font-weight: 400;
     line-height: 1.4;
-    color: $color_font-dark;
+    color: #1f2937;
+    max-width: 240px;
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: break-word;
+
+    > div + div {
+      margin-top: 0.25rem;
+    }
+  }
+
+  .dataset-map-preview__hover-tooltip-row {
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: break-word;
+
+    strong,
+    span {
+      white-space: normal;
+      overflow-wrap: break-word;
+      word-break: break-word;
+    }
+
+    &--metric {
+      display: flex;
+      flex-wrap: nowrap;
+      align-items: flex-start;
+      gap: 6px;
+
+      strong {
+        flex: 1 1 auto;
+        min-width: 0;
+        max-width: calc(100% - 4.5rem);
+        font-weight: 700;
+        white-space: normal;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+
+      span {
+        flex: 0 0 auto;
+        white-space: nowrap;
+        overflow-wrap: normal;
+        word-break: normal;
+      }
+    }
+  }
+
+  .dataset-map-preview__mapbox-popup {
+    .mapboxgl-popup-content {
+      max-width: 260px;
+      padding: 8px 10px;
+      border-radius: 6px;
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.18);
+      white-space: normal;
+      overflow-wrap: break-word;
+      word-break: break-word;
+    }
+  }
+
+  .dataset-map-preview__metadata {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0 1em;
+    margin-top: 0.35rem;
+    font-size: $font_size-xsmall;
+    font-style: italic;
+    color: $color_font-medium;
+    line-height: 1.4;
+
+    .link a {
+      color: $color_font-medium;
+      text-decoration: underline;
+
+      &:hover {
+        color: $color_font-dark;
+      }
+    }
   }
 
   .dataset-map-preview__status {
@@ -2281,6 +2457,49 @@
       word-break: break-word;
     }
 
+    &--inline {
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: flex-start;
+      gap: 8px;
+
+      dt {
+        flex: 0 1 auto;
+        min-width: 0;
+        text-transform: none;
+        letter-spacing: normal;
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: $color_font-dark;
+        white-space: normal;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+
+      dd {
+        flex: 1 1 auto;
+        min-width: 0;
+        text-align: left;
+        white-space: normal;
+        overflow-wrap: break-word;
+        word-break: break-word;
+      }
+    }
+
+    &--metric {
+      dt {
+        flex: 1 1 auto;
+        max-width: calc(100% - 4.5rem);
+      }
+
+      dd {
+        flex: 0 0 auto;
+        white-space: nowrap;
+        overflow-wrap: normal;
+        word-break: normal;
+      }
+    }
+
     &--emphasis dd {
       font-size: 1.15rem;
       font-weight: 700;
@@ -2377,6 +2596,9 @@
     font-weight: 700;
     line-height: 1.35;
     color: $color_font-dark;
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: break-word;
   }
 
   .dataset-map-preview__legend-boundary {

--- a/src/assets/styles/routes/datasets.scss
+++ b/src/assets/styles/routes/datasets.scss
@@ -2318,6 +2318,61 @@
     min-height: 520px;
     background: #e8eef0;
     min-width: 0;
+
+    // Keep Mapbox zoom/compass above map chrome.
+    .mapboxgl-ctrl-bottom-right {
+      z-index: 4;
+      bottom: 8px;
+      right: 8px;
+    }
+
+    .mapboxgl-ctrl-group {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    }
+
+    .mapboxgl-ctrl-compass {
+      display: block !important;
+    }
+  }
+
+  .dataset-map-preview__map-controls {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 4;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+  }
+
+  .dataset-map-preview__north-arrow {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    width: 36px;
+    padding: 6px 4px 4px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid rgba($color_font-medium, 0.22);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+    pointer-events: none;
+  }
+
+  .dataset-map-preview__north-arrow-pointer {
+    width: 0;
+    height: 0;
+    border-left: 7px solid transparent;
+    border-right: 7px solid transparent;
+    border-bottom: 14px solid #c23b2e;
+  }
+
+  .dataset-map-preview__north-arrow-label {
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    color: $color_font-dark;
   }
 
   .dataset-map-preview__detail {
@@ -2508,10 +2563,6 @@
   }
 
   .dataset-map-preview__layer-toggles {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    z-index: 3;
     display: flex;
     flex-direction: column;
     gap: 6px;

--- a/src/components/partials/DatasetHeader.jsx
+++ b/src/components/partials/DatasetHeader.jsx
@@ -760,6 +760,23 @@ function DatasetHeader({
   }, [actionsOpen]);
 
   return (
+    isEmbedView && viewMode === "map" ? (
+      <div className="embed-map-header-actions" role="group" aria-label="Embed map header">
+        <h2 className="embed-map-header-title">{title}</h2>
+        <button
+          type="button"
+          className="embed-view-source-icon-btn"
+          onClick={() => {
+            const url = new URL(`/browser/datasets/${datasetId}/map`, window.location.origin);
+            window.open(url.href, "_blank", "noopener,noreferrer");
+          }}
+          title="View source data"
+          aria-label="View source data in DataCommon in a new tab"
+        >
+          <FontAwesomeIcon icon={faEllipsisVertical} />
+        </button>
+      </div>
+    ) : (
     <div className={isEmbedView ? "page-header page-header-embed" : "page-header"}>
       <div className="container tight">
         {isEmbedView && (
@@ -984,6 +1001,7 @@ function DatasetHeader({
         }}
       />
     </div>
+    )
   );
 }
 

--- a/src/components/partials/DatasetMapPreview.jsx
+++ b/src/components/partials/DatasetMapPreview.jsx
@@ -9,7 +9,6 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { MAP_CONFIG } from "../../constants/mapConfig";
 import {
   MAP_VIEW_GEOGRAPHY_TYPES,
-  NATIVE_BOUNDARY_TABLES,
   buildChoroplethScale,
   buildValueByGeography,
   buildValueByGeographyFromFeatures,

--- a/src/components/partials/DatasetMapPreview.jsx
+++ b/src/components/partials/DatasetMapPreview.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import mapboxgl from "mapbox-gl";
 import MoonLoader from "react-spinners/MoonLoader";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -14,12 +15,14 @@ import {
   enrichBoundariesWithValues,
   fetchDatasetGeometry,
   fetchGisBoundaryLayer,
-  fetchNativeCensusTractBoundaryGeojson,
+  fetchNativeBoundaryGeojson,
   filterRowsForMapPreview,
   formatMapValue,
   getColumnUnit,
+  getMarginColumnForBase,
   getMappableColumns,
-  isNativeCensusTractBoundaryTable,
+  isBoundariesCategory,
+  adaptMunicipalBoundaryGeojson,
   resolveMapGeographyColumn,
 } from "../../utils/datasetMapPreview";
 import { ExportLoadingMask, useExportFileDownload } from "./ExportLoadingMask";
@@ -36,6 +39,126 @@ const MAPC_SOURCE_ID = "dataset-map-preview-mapc";
 const MAPC_LINE_LAYER_ID = "dataset-map-preview-mapc-line";
 const EMPTY_FC = { type: "FeatureCollection", features: [] };
 
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function buildFeatureDetails(props, {
+  mapYear,
+  geographyType,
+  geometryJoinKey,
+  marginColumn,
+} = {}) {
+  if (!props) return null;
+  const rawValue = props.__mapValue;
+  const value = rawValue == null || rawValue === "" ? null : Number(rawValue);
+
+  const municipalName = props.municipal || props.town || props.NAME || null;
+  const formattedMunicipalName = municipalName
+    ? String(municipalName)
+        .toLowerCase()
+        .replace(/\b\w/g, (s) => s.toUpperCase())
+    : null;
+
+  const joinKey = String(props.__joinKey || geometryJoinKey || "").toLowerCase();
+  const isMunicipal =
+    geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal ||
+    joinKey === "muni_id" ||
+    joinKey === "municipal" ||
+    props.muni_id != null;
+
+  const label =
+    (isMunicipal && formattedMunicipalName) ||
+    props.__mapLabel ||
+    formattedMunicipalName ||
+    "Area";
+
+  let tractBoundary = null;
+  if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts) {
+    if (joinKey === "ct20_id" || (props.ct20_id && !props.ct10_id)) {
+      tractBoundary = "2020 Census tracts";
+    } else if (joinKey === "ct10_id" || (props.ct10_id && !props.ct20_id)) {
+      tractBoundary = "2010 Census tracts";
+    } else if (props.ct20_id) {
+      tractBoundary = "2020 Census tracts";
+    } else if (props.ct10_id) {
+      tractBoundary = "2010 Census tracts";
+    }
+  }
+
+  let marginOfError = null;
+  if (marginColumn) {
+    const rawMoe =
+      props.__mapMoe ??
+      props[marginColumn] ??
+      Object.entries(props).find(([key]) => key.toLowerCase() === marginColumn.toLowerCase())?.[1];
+    const moeNum = rawMoe == null || rawMoe === "" ? null : Number(rawMoe);
+    marginOfError = Number.isFinite(moeNum) ? moeNum : null;
+  }
+
+  return {
+    label,
+    value: Number.isFinite(value) ? value : null,
+    marginOfError,
+    year: mapYear != null ? String(mapYear) : null,
+    tractBoundary,
+  };
+}
+
+function featureDetailsToPopupHtml(details, {
+  geographyType,
+  activeVariableLabel,
+  activeVariableUnit,
+} = {}) {
+  if (!details) return "";
+  const placeLabel =
+    geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts
+      ? "Census tract"
+      : geographyType === MAP_VIEW_GEOGRAPHY_TYPES.boundary
+        ? "Feature"
+        : "Municipality";
+  const valueText = formatMapValue(details.value, activeVariableUnit);
+  const moeText =
+    details.marginOfError != null
+      ? ` ± ${formatMapValue(details.marginOfError, activeVariableUnit)}`
+      : "";
+
+  const rows = [
+    `<div class="dataset-map-preview__hover-tooltip-row"><strong>${escapeHtml(placeLabel)}:</strong> <span>${escapeHtml(details.label)}</span></div>`,
+  ];
+  if (details.year) {
+    rows.push(
+      `<div class="dataset-map-preview__hover-tooltip-row"><strong>Year:</strong> <span>${escapeHtml(details.year)}</span></div>`,
+    );
+  }
+  if (details.tractBoundary) {
+    rows.push(
+      `<div class="dataset-map-preview__hover-tooltip-row"><strong>Boundary:</strong> <span>${escapeHtml(details.tractBoundary)}</span></div>`,
+    );
+  }
+  if (activeVariableLabel) {
+    rows.push(
+      `<div class="dataset-map-preview__hover-tooltip-row dataset-map-preview__hover-tooltip-row--metric"><strong>${escapeHtml(activeVariableLabel)}:</strong> <span>${escapeHtml(valueText)}${escapeHtml(moeText)}</span></div>`,
+    );
+  }
+  return `<div class="dataset-map-preview__hover-tooltip">${rows.join("")}</div>`;
+}
+
+function bringOverlayLayersToFront(map) {
+  if (!map) return;
+  // Keep reference overlays above the choropleth fill/outline so toggles are visible.
+  if (map.getLayer(MUNI_LINE_LAYER_ID)) {
+    map.moveLayer(MUNI_LINE_LAYER_ID);
+  }
+  if (map.getLayer(MAPC_LINE_LAYER_ID)) {
+    map.moveLayer(MAPC_LINE_LAYER_ID);
+  }
+}
+
 function DatasetMapPreview({
   rows = [],
   columnKeys = [],
@@ -48,10 +171,16 @@ function DatasetMapPreview({
   geographyType = null,
   mapVariable = null,
   onMapVariableChange,
+  menu1 = null,
+  title = "",
+  source = "",
+  datasetId = null,
   database = "ds",
   schema = "tabular",
   table = "",
 }) {
+  const location = useLocation();
+  const isEmbedView = new URLSearchParams(location.search).get("embed") === "1";
   const municipalGeojson = useSelector((state) => state.municipality.geojson);
   const mapContainerRef = useRef(null);
   const mapRef = useRef(null);
@@ -66,6 +195,7 @@ function DatasetMapPreview({
   const [muniOverlayGeojson, setMuniOverlayGeojson] = useState(EMPTY_FC);
   const [mapcOverlayGeojson, setMapcOverlayGeojson] = useState(EMPTY_FC);
   const [selectedFeatureKey, setSelectedFeatureKey] = useState(null);
+  const hoverPopupRef = useRef(null);
   const { isExporting, exportError, runExportDownload, clearExportError } = useExportFileDownload();
 
   const filteredRows = useMemo(
@@ -127,6 +257,11 @@ function DatasetMapPreview({
     return getColumnUnit(column);
   }, [activeVariable, columnKeys, mappableColumns]);
 
+  const marginColumn = useMemo(
+    () => getMarginColumnForBase(columnKeys, activeVariable),
+    [columnKeys, activeVariable],
+  );
+
   useEffect(() => {
     if (!activeVariable) return;
     if (mapVariable !== activeVariable) {
@@ -142,15 +277,22 @@ function DatasetMapPreview({
     const loadOverlays = async () => {
       setOverlaysLoading(true);
       try {
-        const [muniFc, mapcFc] = await Promise.all([
+        // Load independently so one failure (e.g. unauthorized MAPC table) does not block both.
+        const [muniResult, mapcResult] = await Promise.allSettled([
           fetchGisBoundaryLayer("municipal"),
           fetchGisBoundaryLayer("mapcRegion"),
         ]);
         if (cancelled) return;
-        setMuniOverlayGeojson(muniFc);
-        setMapcOverlayGeojson(mapcFc);
-      } catch (err) {
-        console.error("Failed to load map overlay boundaries from gisdata:", err);
+        if (muniResult.status === "fulfilled") {
+          setMuniOverlayGeojson(muniResult.value);
+        } else {
+          console.error("Failed to load municipal overlay boundaries:", muniResult.reason);
+        }
+        if (mapcResult.status === "fulfilled") {
+          setMapcOverlayGeojson(mapcResult.value);
+        } else {
+          console.error("Failed to load MAPC region overlay boundaries:", mapcResult.reason);
+        }
       } finally {
         if (!cancelled) {
           setOverlaysLoading(false);
@@ -165,12 +307,21 @@ function DatasetMapPreview({
   }, []);
 
   const isBoundaryLoading = boundariesLoading || overlaysLoading;
+  // Boundaries category tables already have polygons in `shape` — no geometry-API join.
+  const isBoundariesDataset = isBoundariesCategory(menu1);
+  const shapeAttributeColumns = useMemo(
+    () => (columnKeys || []).map((col) => col?.name).filter(Boolean),
+    [columnKeys],
+  );
+  const boundaryLayerLabel = title || "Boundaries";
+
   useEffect(() => {
     const usesGeometryApi =
-      geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts ||
-      geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal;
+      !isBoundariesDataset &&
+      (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts ||
+        geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal);
 
-    if (!usesGeometryApi) {
+    if (!usesGeometryApi && !isBoundariesDataset) {
       setApiBoundaryGeojson(null);
       setGeometryJoinKey(null);
       setBoundariesError("");
@@ -190,12 +341,21 @@ function DatasetMapPreview({
     const loadBoundaries = async () => {
       try {
         let result;
-        if (isNativeCensusTractBoundaryTable(table)) {
-          // Boundary datasets store polygons in `shape` — draw from that column.
-          result = await fetchNativeCensusTractBoundaryGeojson({
+        if (table === "ma_municipalities" && municipalGeojson?.features?.length) {
+          // Static Redux polygons are already WGS84 — avoid a multi‑MB ST_AsText round-trip.
+          result = {
+            featureCollection: adaptMunicipalBoundaryGeojson(municipalGeojson),
+            joinKey: "muni_id",
+            boundaryLabel: boundaryLayerLabel,
+          };
+        } else if (isBoundariesDataset) {
+          // Load this table’s own `shape` column.
+          result = await fetchNativeBoundaryGeojson({
             database,
             schema,
             table,
+            columnNames: shapeAttributeColumns,
+            boundaryLabel: boundaryLayerLabel,
           });
         } else {
           const years = mapYear != null ? [mapYear] : [];
@@ -215,8 +375,7 @@ function DatasetMapPreview({
         if (cancelled) return;
         setApiBoundaryGeojson(null);
         setGeometryJoinKey(null);
-        if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal) {
-          // Fall back to Redux municipal polygons + client-side join
+        if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal && !isBoundariesDataset) {
           setBoundariesError(
             primaryError?.message
               ? `Geometry API unavailable (${primaryError.message}); using fallback boundaries`
@@ -224,7 +383,7 @@ function DatasetMapPreview({
           );
         } else {
           setBoundariesError(
-            primaryError?.message || "Unable to load census tract boundaries",
+            primaryError?.message || "Unable to load map boundaries",
           );
         }
         setBoundariesLoading(false);
@@ -236,15 +395,30 @@ function DatasetMapPreview({
     return () => {
       cancelled = true;
     };
-  }, [geographyType, database, schema, table, mapYear, queryYearColumn]);
+  }, [
+    geographyType,
+    database,
+    schema,
+    table,
+    mapYear,
+    queryYearColumn,
+    municipalGeojson,
+    isBoundariesDataset,
+    shapeAttributeColumns,
+    boundaryLayerLabel,
+  ]);
 
-  const baseGeojson =
-    apiBoundaryGeojson ||
-    (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal && !boundariesLoading
-      ? municipalGeojson
-      : null);
+  const baseGeojson = useMemo(() => {
+    if (apiBoundaryGeojson) return apiBoundaryGeojson;
+    if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal && !boundariesLoading && municipalGeojson) {
+      return adaptMunicipalBoundaryGeojson(municipalGeojson);
+    }
+    return null;
+  }, [apiBoundaryGeojson, geographyType, boundariesLoading, municipalGeojson]);
 
   const tractBoundaryLabel = useMemo(() => {
+    if (isBoundariesDataset) return null;
+
     if (geographyType !== MAP_VIEW_GEOGRAPHY_TYPES.census_tracts) return null;
     const joinKey = String(geometryJoinKey || "").toLowerCase();
     const props = baseGeojson?.features?.[0]?.properties || {};
@@ -260,7 +434,7 @@ function DatasetMapPreview({
     if (props.ct20_id) return "2020 Census tracts";
     if (props.ct10_id) return "2010 Census tracts";
     return null;
-  }, [geographyType, geometryJoinKey, baseGeojson]);
+  }, [isBoundariesDataset, geographyType, geometryJoinKey, baseGeojson]);
 
   const valueByGeography = useMemo(() => {
     if (!activeVariable) return new Map();
@@ -293,20 +467,58 @@ function DatasetMapPreview({
     apiBoundaryGeojson,
   ]);
 
-  const { colorForValue, legend, binningDescription } = useMemo(
-    () => buildChoroplethScale([...valueByGeography.values()], { unit: activeVariableUnit }),
-    [valueByGeography, activeVariableUnit],
-  );
+  const moeByGeography = useMemo(() => {
+    if (!marginColumn) return null;
+
+    if (apiBoundaryGeojson?.features?.length) {
+      const fromFeatures = buildValueByGeographyFromFeatures({
+        features: apiBoundaryGeojson.features,
+        valueColumn: marginColumn,
+        geographyType,
+      });
+      if (fromFeatures.size) return fromFeatures;
+    }
+
+    if (!geographyColumn) return null;
+    return buildValueByGeography({
+      rows: filteredRows,
+      geographyColumn,
+      valueColumn: marginColumn,
+      yearColumn: queryYearColumn,
+      geographyType,
+    });
+  }, [
+    marginColumn,
+    apiBoundaryGeojson,
+    geographyType,
+    geographyColumn,
+    filteredRows,
+    queryYearColumn,
+  ]);
+
+  const { colorForValue, legend, binningDescription } = useMemo(() => {
+    const values = [...valueByGeography.values()];
+    if (!values.length && isBoundariesDataset) {
+      const boundaryColor = "#7eb8c9";
+      return {
+        colorForValue: () => boundaryColor,
+        legend: [{ label: boundaryLayerLabel, color: boundaryColor }],
+        binningDescription: "Classification: Boundary outline",
+      };
+    }
+    return buildChoroplethScale(values, { unit: activeVariableUnit });
+  }, [valueByGeography, activeVariableUnit, boundaryLayerLabel, isBoundariesDataset]);
 
   const paintedGeojson = useMemo(() => {
     if (!baseGeojson) return { type: "FeatureCollection", features: [] };
     return enrichBoundariesWithValues({
       baseGeojson,
       valueByGeography,
+      moeByGeography,
       geographyType,
       colorForValue,
     });
-  }, [baseGeojson, valueByGeography, geographyType, colorForValue]);
+  }, [baseGeojson, valueByGeography, moeByGeography, geographyType, colorForValue]);
 
   useEffect(() => {
     if (!mapContainerRef.current || mapRef.current) return undefined;
@@ -314,14 +526,16 @@ function DatasetMapPreview({
     const map = new mapboxgl.Map({
       container: mapContainerRef.current,
       style: MAP_CONFIG.style,
-      dragRotate: false,
+      dragRotate: true,
+      touchPitch: false,
+      pitchWithRotate: false,
       bounds: MAP_CONFIG.bounds,
       fitBoundsOptions: { padding: { top: 24, bottom: 24, left: 24, right: 24 }, animate: false },
     });
 
     map.addControl(
       new mapboxgl.NavigationControl({
-        showCompass: false,
+        showCompass: true,
         showZoom: true,
         visualizePitch: false,
       }),
@@ -364,7 +578,7 @@ function DatasetMapPreview({
           "line-width": 2.4,
           "line-opacity": 1,
         },
-        filter: ["==", ["get", "__mapKey"], ""],
+        filter: ["==", ["get", "__mapKey"], "__none__"],
       });
 
       map.addSource(MUNI_SOURCE_ID, {
@@ -378,8 +592,8 @@ function DatasetMapPreview({
         layout: { visibility: "none" },
         paint: {
           "line-color": "#094A72",
-          "line-width": 0.9,
-          "line-opacity": 0.9,
+          "line-width": 1.6,
+          "line-opacity": 1,
         },
       });
 
@@ -393,11 +607,13 @@ function DatasetMapPreview({
         source: MAPC_SOURCE_ID,
         layout: { visibility: "none" },
         paint: {
-          "line-color": "#ED948D",
-          "line-width": 2,
+          "line-color": "#C23B2E",
+          "line-width": 2.5,
           "line-opacity": 1,
         },
       });
+
+      bringOverlayLayersToFront(map);
 
       map.on("mouseenter", FILL_LAYER_ID, () => {
         map.getCanvas().style.cursor = "pointer";
@@ -412,7 +628,18 @@ function DatasetMapPreview({
 
     mapRef.current = map;
 
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" && mapContainerRef.current
+        ? new ResizeObserver(() => {
+            map.resize();
+          })
+        : null;
+    if (resizeObserver && mapContainerRef.current) {
+      resizeObserver.observe(mapContainerRef.current);
+    }
+
     return () => {
+      resizeObserver?.disconnect();
       map.remove();
       mapRef.current = null;
       setMapReady(false);
@@ -428,6 +655,7 @@ function DatasetMapPreview({
     if (source) {
       source.setData(muniOverlayGeojson || EMPTY_FC);
     }
+    bringOverlayLayersToFront(map);
   }, [muniOverlayGeojson, mapReady]);
 
   useEffect(() => {
@@ -437,6 +665,7 @@ function DatasetMapPreview({
     if (source) {
       source.setData(mapcOverlayGeojson || EMPTY_FC);
     }
+    bringOverlayLayersToFront(map);
   }, [mapcOverlayGeojson, mapReady]);
 
   useEffect(() => {
@@ -445,6 +674,7 @@ function DatasetMapPreview({
     const visibility = showMunicipalLayer ? "visible" : "none";
     if (map.getLayer(MUNI_LINE_LAYER_ID)) {
       map.setLayoutProperty(MUNI_LINE_LAYER_ID, "visibility", visibility);
+      if (showMunicipalLayer) bringOverlayLayersToFront(map);
     }
   }, [showMunicipalLayer, mapReady]);
 
@@ -454,6 +684,7 @@ function DatasetMapPreview({
     const visibility = showMapcRegionLayer ? "visible" : "none";
     if (map.getLayer(MAPC_LINE_LAYER_ID)) {
       map.setLayoutProperty(MAPC_LINE_LAYER_ID, "visibility", visibility);
+      if (showMapcRegionLayer) bringOverlayLayersToFront(map);
     }
   }, [showMapcRegionLayer, mapReady]);
 
@@ -471,7 +702,32 @@ function DatasetMapPreview({
         geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts ? 0.4 : 0.7,
       );
     }
-  }, [paintedGeojson, mapReady, geographyType]);
+    if (isBoundariesDataset && paintedGeojson?.features?.length) {
+      const bounds = new mapboxgl.LngLatBounds();
+      let hasCoord = false;
+      const extendCoords = (coords) => {
+        if (!Array.isArray(coords) || !coords.length) return;
+        if (typeof coords[0] === "number") {
+          if (Number.isFinite(coords[0]) && Number.isFinite(coords[1])) {
+            bounds.extend([coords[0], coords[1]]);
+            hasCoord = true;
+          }
+          return;
+        }
+        coords.forEach(extendCoords);
+      };
+      paintedGeojson.features.forEach((feature) => extendCoords(feature?.geometry?.coordinates));
+      if (hasCoord && !bounds.isEmpty()) {
+        map.fitBounds(bounds, {
+          padding: { top: 28, bottom: 28, left: 28, right: 28 },
+          animate: false,
+          maxZoom: 12,
+        });
+      }
+    }
+    // Choropleth updates can reshuffle paint order; keep overlays on top.
+    bringOverlayLayersToFront(map);
+  }, [paintedGeojson, mapReady, geographyType, isBoundariesDataset]);
 
   useEffect(() => {
     setSelectedFeatureKey(null);
@@ -480,16 +736,67 @@ function DatasetMapPreview({
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !mapReady || !map.getLayer(SELECTED_LINE_LAYER_ID)) return;
-    map.setFilter(SELECTED_LINE_LAYER_ID, [
-      "==",
-      ["to-string", ["get", "__mapKey"]],
-      selectedFeatureKey != null ? String(selectedFeatureKey) : "",
-    ]);
+    // Use a non-matching sentinel when nothing is selected — matching "" would
+    // highlight every feature whose __mapKey is missing/empty.
+    map.setFilter(
+      SELECTED_LINE_LAYER_ID,
+      selectedFeatureKey != null && selectedFeatureKey !== ""
+        ? ["==", ["to-string", ["get", "__mapKey"]], String(selectedFeatureKey)]
+        : ["==", ["get", "__mapKey"], "__none__"],
+    );
   }, [selectedFeatureKey, mapReady, paintedGeojson]);
 
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !mapReady) return undefined;
+
+    if (isEmbedView) {
+      if (!hoverPopupRef.current) {
+        hoverPopupRef.current = new mapboxgl.Popup({
+          closeButton: false,
+          closeOnClick: false,
+          offset: 12,
+          maxWidth: "260px",
+          className: "dataset-map-preview__mapbox-popup",
+        });
+      }
+      const popup = hoverPopupRef.current;
+
+      const onMouseMove = (e) => {
+        const feature = e.features?.[0];
+        if (!feature) return;
+        map.getCanvas().style.cursor = "pointer";
+        const details = buildFeatureDetails(feature.properties, {
+          mapYear,
+          geographyType,
+          geometryJoinKey,
+          marginColumn,
+        });
+        popup
+          .setLngLat(e.lngLat)
+          .setHTML(
+            featureDetailsToPopupHtml(details, {
+              geographyType,
+              activeVariableLabel,
+              activeVariableUnit,
+            }),
+          )
+          .addTo(map);
+      };
+
+      const onMouseLeave = () => {
+        map.getCanvas().style.cursor = "";
+        popup.remove();
+      };
+
+      map.on("mousemove", FILL_LAYER_ID, onMouseMove);
+      map.on("mouseleave", FILL_LAYER_ID, onMouseLeave);
+      return () => {
+        map.off("mousemove", FILL_LAYER_ID, onMouseMove);
+        map.off("mouseleave", FILL_LAYER_ID, onMouseLeave);
+        popup.remove();
+      };
+    }
 
     const onFeatureClick = (e) => {
       const feature = e.features?.[0];
@@ -510,7 +817,16 @@ function DatasetMapPreview({
       map.off("click", FILL_LAYER_ID, onFeatureClick);
       map.off("click", onMapClick);
     };
-  }, [mapReady]);
+  }, [
+    mapReady,
+    isEmbedView,
+    mapYear,
+    geographyType,
+    geometryJoinKey,
+    marginColumn,
+    activeVariableLabel,
+    activeVariableUnit,
+  ]);
 
   const selectedFeature = useMemo(() => {
     if (selectedFeatureKey == null) return null;
@@ -523,50 +839,13 @@ function DatasetMapPreview({
 
   const selectedDetails = useMemo(() => {
     if (!selectedFeature?.properties) return null;
-    const props = selectedFeature.properties;
-    const rawValue = props.__mapValue;
-    const value = rawValue == null || rawValue === "" ? null : Number(rawValue);
-
-    const municipalName = props.municipal || props.town || props.NAME || null;
-    const formattedMunicipalName = municipalName
-      ? String(municipalName)
-          .toLowerCase()
-          .replace(/\b\w/g, (s) => s.toUpperCase())
-      : null;
-
-    const joinKey = String(props.__joinKey || geometryJoinKey || "").toLowerCase();
-    const isMunicipal =
-      geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal ||
-      joinKey === "muni_id" ||
-      joinKey === "municipal" ||
-      props.muni_id != null;
-
-    const label =
-      (isMunicipal && formattedMunicipalName) ||
-      props.__mapLabel ||
-      formattedMunicipalName ||
-      "Area";
-
-    let tractBoundary = null;
-    if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts) {
-      if (joinKey === "ct20_id" || (props.ct20_id && !props.ct10_id)) {
-        tractBoundary = "2020 Census tracts";
-      } else if (joinKey === "ct10_id" || (props.ct10_id && !props.ct20_id)) {
-        tractBoundary = "2010 Census tracts";
-      } else if (props.ct20_id) {
-        tractBoundary = "2020 Census tracts";
-      } else if (props.ct10_id) {
-        tractBoundary = "2010 Census tracts";
-      }
-    }
-
-    return {
-      label,
-      value: Number.isFinite(value) ? value : null,
-      year: mapYear != null ? String(mapYear) : null,
-      tractBoundary,
-    };
-  }, [selectedFeature, mapYear, geographyType, geometryJoinKey]);
+    return buildFeatureDetails(selectedFeature.properties, {
+      mapYear,
+      geographyType,
+      geometryJoinKey,
+      marginColumn,
+    });
+  }, [selectedFeature, mapYear, geographyType, geometryJoinKey, marginColumn]);
 
   const canDownloadGeojson = Boolean(table) && !isBoundaryLoading && !isExporting;
 
@@ -596,7 +875,7 @@ function DatasetMapPreview({
   if (!geographyType) {
     return (
       <div className="dataset-map-preview dataset-map-preview--empty">
-        <p>Map preview is available for municipal and census tract tables.</p>
+        <p>Map preview is available for municipal, census tract, and Boundaries datasets.</p>
       </div>
     );
   }
@@ -611,7 +890,9 @@ function DatasetMapPreview({
     );
   }
 
-  if (!mappableColumns.length && !isBoundaryLoading && !apiBoundaryGeojson) {
+  // Boundary-only layers (e.g. Boundaries category / ma_municipalities) have no numeric choropleth columns.
+  const isBoundaryOnlyMap = isBoundariesDataset || Boolean(apiBoundaryGeojson);
+  if (!mappableColumns.length && !isBoundaryLoading && !isBoundaryOnlyMap) {
     return (
       <div className="dataset-map-preview dataset-map-preview--empty">
         <p>Select at least one numeric column to preview on the map.</p>
@@ -619,49 +900,40 @@ function DatasetMapPreview({
     );
   }
 
-  if (!geographyColumn || !mappableColumns.length) {
-    return (
-      <div className="dataset-map-preview dataset-map-preview--empty">
-        <div className="dataset-map-preview__loading" role="status" aria-live="polite" aria-label="Loading map">
-          <MoonLoader size={42} color="#767676" />
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="dataset-map-preview">
+    <div className={`dataset-map-preview${isEmbedView ? " dataset-map-preview--embed" : ""}`}>
       <div className="dataset-map-preview__map-panel">
-        <div className="dataset-map-preview__map-header">
-          <h2>
-            {mapYear != null && activeVariableLabel
-              ? `${mapYear} ${activeVariableLabel}`
-              : activeVariableLabel || (mapYear != null ? String(mapYear) : "")}
-          </h2>
-          {boundariesError && <span className="dataset-map-preview__status dataset-map-preview__status--error">{boundariesError}</span>}
-        </div>
+        {boundariesError && (
+          <span className="dataset-map-preview__status dataset-map-preview__status--error">{boundariesError}</span>
+        )}
         <div className="dataset-map-preview__map-body">
           <div className="dataset-map-preview__map-shell">
-            <ExportLoadingMask active={isExporting} />
-            <div className="dataset-map-preview__layer-toggles" role="group" aria-label="Map overlay layers">
-              <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
-                <input
-                  type="checkbox"
-                  checked={showMunicipalLayer}
-                  disabled={overlaysLoading}
-                  onChange={(e) => setShowMunicipalLayer(e.target.checked)}
-                />
-                <span>Municipal boundaries</span>
-              </label>
-              <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
-                <input
-                  type="checkbox"
-                  checked={showMapcRegionLayer}
-                  disabled={overlaysLoading}
-                  onChange={(e) => setShowMapcRegionLayer(e.target.checked)}
-                />
-                <span>MAPC region</span>
-              </label>
+            {!isEmbedView && <ExportLoadingMask active={isExporting} />}
+            <div className="dataset-map-preview__map-controls">
+              <div className="dataset-map-preview__north-arrow" aria-hidden="true" title="North">
+                <span className="dataset-map-preview__north-arrow-pointer" />
+                <span className="dataset-map-preview__north-arrow-label">N</span>
+              </div>
+              <div className="dataset-map-preview__layer-toggles" role="group" aria-label="Map overlay layers">
+                <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
+                  <input
+                    type="checkbox"
+                    checked={showMunicipalLayer}
+                    disabled={overlaysLoading}
+                    onChange={(e) => setShowMunicipalLayer(e.target.checked)}
+                  />
+                  <span>Municipal boundaries</span>
+                </label>
+                <label className={`dataset-map-preview__layer-toggle${overlaysLoading ? " dataset-map-preview__layer-toggle--disabled" : ""}`}>
+                  <input
+                    type="checkbox"
+                    checked={showMapcRegionLayer}
+                    disabled={overlaysLoading}
+                    onChange={(e) => setShowMapcRegionLayer(e.target.checked)}
+                  />
+                  <span>MAPC region</span>
+                </label>
+              </div>
             </div>
             <div ref={mapContainerRef} className="dataset-map-preview__map" role="img" aria-label={`Choropleth map of ${activeVariableLabel}`} />
             {isBoundaryLoading && (
@@ -689,111 +961,165 @@ function DatasetMapPreview({
             </div>
           </div>
 
-          <div className="dataset-map-preview__side-panels">
-            <aside className="dataset-map-preview__detail" aria-label="Map variable">
-              <div className="dataset-map-preview__detail-header">
-                <h2 className="dataset-map-preview__detail-title">Variable</h2>
-              </div>
-              <label className="dataset-map-preview__variable-field">
-                <span className="dataset-map-preview__variable-field-label">Choose a column to color the map</span>
-                <select
-                  className="dataset-map-preview__variable-select"
-                  value={activeVariable || ""}
-                  onChange={(e) => onMapVariableChange?.(e.target.value)}
-                  aria-label="Map variable"
-                  title={activeVariableLabel || undefined}
-                >
-                  {mappableColumns.map((col) => (
-                    <option key={col.name} value={col.name}>
-                      {col.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </aside>
-
-            <aside className="dataset-map-preview__detail" aria-label="Selected area details">
-              <div className="dataset-map-preview__detail-header">
-                <h2 className="dataset-map-preview__detail-title">Details</h2>
-                {selectedDetails && (
-                  <button
-                    type="button"
-                    className="dataset-map-preview__detail-close"
-                    onClick={() => setSelectedFeatureKey(null)}
-                    aria-label="Clear selection"
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-              {!selectedDetails ? (
-                <p className="dataset-map-preview__detail-empty">
-                  Click a{" "}
-                  {geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts
-                    ? "census tract"
-                    : "municipality"}{" "}
-                  on the map to view its values.
-                </p>
-              ) : (
-                <dl className="dataset-map-preview__detail-list">
-                  <div className="dataset-map-preview__detail-row">
-                    <dt>
-                      {geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts
-                        ? "Census tract"
-                        : "Municipality"}
-                    </dt>
-                    <dd>{selectedDetails.label}</dd>
-                  </div>
-                  {selectedDetails.year && (
-                    <div className="dataset-map-preview__detail-row">
-                      <dt>Year</dt>
-                      <dd>{selectedDetails.year}</dd>
-                    </div>
-                  )}
-                  {selectedDetails.tractBoundary && (
-                    <div className="dataset-map-preview__detail-row">
-                      <dt>Boundary</dt>
-                      <dd>{selectedDetails.tractBoundary}</dd>
-                    </div>
-                  )}
-                  <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--emphasis">
-                    <dt>{activeVariableLabel}</dt>
-                    <dd>{formatMapValue(selectedDetails.value, activeVariableUnit)}</dd>
-                  </div>
-                </dl>
-              )}
-              <div className="dataset-map-preview__download-wrap">
-                <button
-                  type="button"
-                  className="dataset-map-preview__download-geojson"
-                  onClick={handleDownloadGeojson}
-                  disabled={!canDownloadGeojson}
-                  aria-busy={isExporting}
-                  aria-describedby="dataset-map-geojson-download-tip"
-                >
-                  {isExporting ? "Preparing…" : "Download as GeoJSON"}
-                </button>
-                <span
-                  id="dataset-map-geojson-download-tip"
-                  role="tooltip"
-                  className="dataset-map-preview__download-tooltip"
-                >
-                  {mapYear != null
-                    ? `Download the current map with selected year ${mapYear} as GeoJSON, with all table properties.`
-                    : "Download the current map as GeoJSON, with all table properties."}
-                </span>
-                {exportError && (
-                  <p className="dataset-map-preview__download-error" role="alert">
-                    {exportError}
+          {!isEmbedView && (
+            <div className="dataset-map-preview__side-panels">
+              <aside className="dataset-map-preview__detail" aria-label="Map variable">
+                <div className="dataset-map-preview__detail-header">
+                  <h2 className="dataset-map-preview__detail-title">Variable</h2>
+                </div>
+                {mappableColumns.length ? (
+                  <label className="dataset-map-preview__variable-field">
+                    <span className="dataset-map-preview__variable-field-label">Choose a column to color the map</span>
+                    <select
+                      className="dataset-map-preview__variable-select"
+                      value={activeVariable || ""}
+                      onChange={(e) => onMapVariableChange?.(e.target.value)}
+                      aria-label="Map variable"
+                      title={activeVariableLabel || undefined}
+                    >
+                      {mappableColumns.map((col) => (
+                        <option key={col.name} value={col.name}>
+                          {col.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : (
+                  <p className="dataset-map-preview__variable-field-label">
+                    This boundary layer has no numeric columns to choropleth. Click a feature for details.
                   </p>
                 )}
-              </div>
-            </aside>
-          </div>
+              </aside>
+
+              <aside className="dataset-map-preview__detail" aria-label="Selected area details">
+                <div className="dataset-map-preview__detail-header">
+                  <h2 className="dataset-map-preview__detail-title">Details</h2>
+                  {selectedDetails && (
+                    <button
+                      type="button"
+                      className="dataset-map-preview__detail-close"
+                      onClick={() => setSelectedFeatureKey(null)}
+                      aria-label="Clear selection"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+                {!selectedDetails ? (
+                  <p className="dataset-map-preview__detail-empty">
+                    Click a{" "}
+                    {geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts
+                      ? "census tract"
+                      : geographyType === MAP_VIEW_GEOGRAPHY_TYPES.boundary
+                        ? "feature"
+                        : "municipality"}{" "}
+                    on the map to view its values.
+                  </p>
+                ) : (
+                  <dl className="dataset-map-preview__detail-list">
+                    <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--inline">
+                      <dt>
+                        {geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts
+                          ? "Census tract"
+                          : geographyType === MAP_VIEW_GEOGRAPHY_TYPES.boundary
+                            ? "Feature"
+                            : "Municipality"}
+                      </dt>
+                      <dd>{selectedDetails.label}</dd>
+                    </div>
+                    {selectedDetails.year && (
+                      <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--inline">
+                        <dt>Year</dt>
+                        <dd>{selectedDetails.year}</dd>
+                      </div>
+                    )}
+                    {selectedDetails.tractBoundary && (
+                      <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--inline">
+                        <dt>Boundary</dt>
+                        <dd>{selectedDetails.tractBoundary}</dd>
+                      </div>
+                    )}
+                    <div className="dataset-map-preview__detail-row dataset-map-preview__detail-row--inline dataset-map-preview__detail-row--metric">
+                      <dt>{activeVariableLabel}</dt>
+                      <dd>
+                        {formatMapValue(selectedDetails.value, activeVariableUnit)}
+                        {selectedDetails.marginOfError != null && (
+                          <span className="dataset-map-preview__detail-metric-moe">
+                            {" "}
+                            ± {formatMapValue(selectedDetails.marginOfError, activeVariableUnit)}
+                          </span>
+                        )}
+                      </dd>
+                    </div>
+                  </dl>
+                )}
+                <div className="dataset-map-preview__download-wrap">
+                  <button
+                    type="button"
+                    className="dataset-map-preview__download-geojson"
+                    onClick={handleDownloadGeojson}
+                    disabled={!canDownloadGeojson}
+                    aria-busy={isExporting}
+                    aria-describedby="dataset-map-geojson-download-tip"
+                  >
+                    {isExporting ? "Preparing…" : "Download as GeoJSON"}
+                  </button>
+                  <span
+                    id="dataset-map-geojson-download-tip"
+                    role="tooltip"
+                    className="dataset-map-preview__download-tooltip"
+                  >
+                    {mapYear != null
+                      ? `Download the current map with selected year ${mapYear} as GeoJSON, with all table properties.`
+                      : "Download the current map as GeoJSON, with all table properties."}
+                  </span>
+                  {exportError && (
+                    <p className="dataset-map-preview__download-error" role="alert">
+                      {exportError}
+                    </p>
+                  )}
+                </div>
+              </aside>
+            </div>
+          )}
         </div>
-        {binningDescription && (
-          <p className="dataset-map-preview__map-footer">{binningDescription}</p>
-        )}
+        <div className="metadata dataset-map-preview__metadata">
+          {binningDescription && (
+            <span className="dataset-map-preview__metadata-item">{binningDescription}</span>
+          )}
+          <span className="dataset-map-preview__metadata-item">
+            Source:
+            {" "}
+            {source || "Unknown"}
+          </span>
+          <span className="dataset-map-preview__metadata-item">
+            Years:
+            {" "}
+            {mapYear != null
+              ? String(mapYear)
+              : selectedYears?.length
+                ? selectedYears.map(String).join(", ")
+                : "N/A"}
+          </span>
+          {datasetId != null && datasetId !== "" && title && (
+            <span className="dataset-map-preview__metadata-item link">
+              Link to:
+              {" "}
+              <a
+                href={`/browser/datasets/${datasetId}/map${(() => {
+                  const params = new URLSearchParams(location.search || "");
+                  params.delete("embed");
+                  const qs = params.toString();
+                  return qs ? `?${qs}` : "";
+                })()}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {title}
+              </a>
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -811,10 +1137,15 @@ DatasetMapPreview.propTypes = {
   geographyType: PropTypes.oneOf([
     MAP_VIEW_GEOGRAPHY_TYPES.municipal,
     MAP_VIEW_GEOGRAPHY_TYPES.census_tracts,
+    MAP_VIEW_GEOGRAPHY_TYPES.boundary,
     null,
   ]),
   mapVariable: PropTypes.string,
   onMapVariableChange: PropTypes.func,
+  menu1: PropTypes.string,
+  title: PropTypes.string,
+  source: PropTypes.string,
+  datasetId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   database: PropTypes.string,
   schema: PropTypes.string,
   table: PropTypes.string,

--- a/src/components/partials/EmbedTableModal.jsx
+++ b/src/components/partials/EmbedTableModal.jsx
@@ -17,8 +17,12 @@ const makeIframeSnippet = (embedUrl, title, w, h, viewMode = "table") =>
   `<iframe src="${embedUrl}" title="${title || (viewMode === "map" ? "Embedded dataset map" : "Embedded dataset table")}" width="${w}" height="${h}" frameborder="0" loading="lazy"></iframe>`;
 
 const digitsOnly = (value) => String(value ?? "").replace(/\D/g, "");
-const getPresetForDimensions = (width, height) => {
-  if (width === SIZE_PRESETS.small.width && height === SIZE_PRESETS.small.height) {
+const getPresetForDimensions = (width, height, viewMode = "table") => {
+  if (
+    viewMode !== "map" &&
+    width === SIZE_PRESETS.small.width &&
+    height === SIZE_PRESETS.small.height
+  ) {
     return "small";
   }
   if (width === SIZE_PRESETS.medium.width && height === SIZE_PRESETS.medium.height) {
@@ -61,9 +65,9 @@ const EmbedTableModal = ({
       setHeightInput(String(IFRAME_HEIGHT_DEFAULT));
       setWidthCommitted(IFRAME_WIDTH_DEFAULT);
       setHeightCommitted(IFRAME_HEIGHT_DEFAULT);
-      setSizePreset(getPresetForDimensions(IFRAME_WIDTH_DEFAULT, IFRAME_HEIGHT_DEFAULT));
+      setSizePreset(getPresetForDimensions(IFRAME_WIDTH_DEFAULT, IFRAME_HEIGHT_DEFAULT, viewMode));
     }
-  }, [isOpen]);
+  }, [isOpen, viewMode]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -127,7 +131,7 @@ const EmbedTableModal = ({
     const c = resolveWidthFromInput();
     setWidthCommitted(c);
     setWidthInput(String(c));
-    setSizePreset(getPresetForDimensions(c, heightCommitted));
+    setSizePreset(getPresetForDimensions(c, heightCommitted, viewMode));
     setCopyStatus("");
   };
 
@@ -135,7 +139,7 @@ const EmbedTableModal = ({
     const c = resolveHeightFromInput();
     setHeightCommitted(c);
     setHeightInput(String(c));
-    setSizePreset(getPresetForDimensions(widthCommitted, c));
+    setSizePreset(getPresetForDimensions(widthCommitted, c, viewMode));
     setCopyStatus("");
   };
 
@@ -169,12 +173,15 @@ const EmbedTableModal = ({
     setHeightCommitted(h);
     setWidthInput(String(w));
     setHeightInput(String(h));
-    setSizePreset(getPresetForDimensions(w, h));
+    setSizePreset(getPresetForDimensions(w, h, viewMode));
     copyText(makeIframeSnippet(embedUrl, title, w, h, viewMode), "Embed code copied!");
   };
 
   const handleSizePresetChange = (e) => {
     const nextPreset = e.target.value;
+    if (viewMode === "map" && nextPreset === "small") {
+      return;
+    }
     setSizePreset(nextPreset);
     setCopyStatus("");
     if (nextPreset === "custom") {
@@ -314,7 +321,9 @@ const EmbedTableModal = ({
                   value={sizePreset}
                   onChange={handleSizePresetChange}
                 >
-                  <option value="small">{`${SIZE_PRESETS.small.width} x ${SIZE_PRESETS.small.height} (Small)`}</option>
+                  {viewMode !== "map" && (
+                    <option value="small">{`${SIZE_PRESETS.small.width} x ${SIZE_PRESETS.small.height} (Small)`}</option>
+                  )}
                   <option value="medium">{`${SIZE_PRESETS.medium.width} x ${SIZE_PRESETS.medium.height} (Medium)`}</option>
                   <option value="large">{`${SIZE_PRESETS.large.width} x ${SIZE_PRESETS.large.height} (Large)`}</option>
                   <option value="custom">Custom</option>

--- a/src/pages/DataViewerPage.jsx
+++ b/src/pages/DataViewerPage.jsx
@@ -60,6 +60,7 @@ class DataViewerClass extends React.Component {
       viewMode: viewModeFromLocation(props.location, props.params),
       mapVariable: null,
       geographyType: null,
+      menu1: null,
     };
     this.updateSelectedYears = this.updateSelectedYears.bind(this);
     this.updateSelectedColumns = this.updateSelectedColumns.bind(this);
@@ -244,20 +245,22 @@ class DataViewerClass extends React.Component {
       return;
     }
 
+
     // construct the query for the data in the table and handle some special cases.
     let limit = 15000;
+    // these tables are large and need a much higher limit
+    // TODO: setup backend pagination and only fetch 25 results at a time?
     if (dataset.table_name === "econ_es202_naics_4d_m" || dataset.table_name === "econ_es202_naics_2d_m" || dataset.table_name === "econ_es202_naics_3d_m") {
-      // these tables are large and need a much higher limit
-      // TODO: setup backend pagination and only fetch 25 results at a time?
       limit = 460000 ;
     }
     let tableQueryUrl = `/api?token=${import.meta.env.VITE_MAPC_API_TOKEN}&database=${dataset.db_name}&schema=${dataset.schemaname}&table=${dataset.table_name}&limit=${limit}`;
     if (dataset.yearcolumn) {
       tableQueryUrl = `${tableQueryUrl}&orderByColumn=${dataset.yearcolumn}&orderByDirection=DESC`;
     }
-    if (dataset.table_name === "_data_browser") {
-      // filter on active datasets if viewing the data browser
-      tableQueryUrl = `${tableQueryUrl}&filters=active:Y`;
+    // Handle only showing select columns in the _data_browser
+    if (dataset.table_name == "_data_browser") {
+      const browserColumns = ["seq_id", "menu1", "menu2", "menu3", "geography", "source", "active", "updated"];
+      tableQueryUrl = `${tableQueryUrl}&columns=${browserColumns.join(',')}`
     }
     const tableQuery = axios.get(tableQueryUrl);
 
@@ -310,17 +313,14 @@ class DataViewerClass extends React.Component {
         const yearOverride = resolveYearsFromUrl(parsedShare, distinctYears);
         if (yearOverride) selectedYears = yearOverride;
 
-        // Initialize geography filter for municipal (_m) tables only.
-        // Dropdown uses name columns (muni_name / municipal); map joins use muni_id separately.
-        // Tract tables still map via resolveMapGeographyColumn inside DatasetMapPreview;
-        // setting geographyColumn here without selectedGeographies would empty the table.
-        // Native census tract boundary tables (gisdata shape) enable map view without a filter dropdown.
+        // Geography from `_data_browser.geography`, or Boundaries category (own `shape`).
         let selectedGeographies = [];
         let availableGeographies = [];
         let geographyColumn = null;
         const geographyType = detectDatasetGeographyType(
           dataset.table_name,
           dataset.geography,
+          { menu1: dataset.menu1 },
         );
         if (dataset.schemaname === "tabular") {
           if (geographyType === "municipal") {
@@ -367,6 +367,7 @@ class DataViewerClass extends React.Component {
           database: dataset.db_name,
           title: dataset.menu3,
           source: dataset.source,
+          menu1: dataset.menu1 || null,
           queryYearColumn: dataset.yearcolumn,
           updatedAt: dataset.updated,
           geographyColumn,
@@ -625,6 +626,7 @@ class DataViewerClass extends React.Component {
             onViewModeChange={this.onViewModeChange}
             mapPreviewSupported={mapPreviewSupported}
             mapVariable={this.state.mapVariable}
+            geographyType={this.state.geographyType}
           />
           {this.state.viewMode === "map" && mapPreviewSupported ? (
             <DatasetMapPreview
@@ -639,6 +641,10 @@ class DataViewerClass extends React.Component {
               geographyType={this.state.geographyType}
               mapVariable={this.state.mapVariable}
               onMapVariableChange={this.onMapVariableChange}
+              menu1={this.state.menu1}
+              title={this.state.title}
+              source={this.state.source}
+              datasetId={this.props.params.id}
               database={this.state.database}
               schema={this.state.schema}
               table={this.state.table}

--- a/src/utils/datasetMapPreview.js
+++ b/src/utils/datasetMapPreview.js
@@ -4,6 +4,9 @@ export const MAP_VIEW_GEOGRAPHY_TYPES = {
   municipal: "municipal",
   census_tracts: "census_tracts",
   block_groups: "block_groups",
+  blocks: "blocks",
+  /** `_data_browser.menu1 === "Boundaries"` — table already has polygons in `shape`. */
+  boundary: "boundary",
 };
 
 const MUNICIPAL_MAP_JOIN_COLUMNS = ["muni_id", "muni_name", "municipal"];
@@ -16,6 +19,54 @@ const TRACT_GEO_COLUMNS = [
   "GEOID",
 ];
 
+const OWN_SHAPE_COLUMN_NAMES = new Set(["shape", "geometry", "geom"]);
+
+/** `_data_browser.menu1 === "Boundaries"` */
+export function isBoundariesCategory(menu1) {
+  return String(menu1 || "").trim().toLowerCase() === "boundaries";
+}
+
+/**
+ * Detect geography type from `_data_browser.geography`, or Boundaries category.
+ * Known geography values: municipal, census_tracts, block_groups, blocks, null.
+ *
+ * @param {string|null|undefined} [_tableName]
+ * @param {string|null|undefined} [geography] `_data_browser.geography`
+ * @param {{ menu1?: string|null }} [options]
+ */
+export function detectDatasetGeographyType(_tableName, geography = null, { menu1 = null } = {}) {
+  if (geography != null && geography !== "") {
+    const value = String(geography).trim().toLowerCase();
+    if (value === MAP_VIEW_GEOGRAPHY_TYPES.municipal) {
+      return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
+    }
+    if (value === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts) {
+      return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
+    }
+    if (value === MAP_VIEW_GEOGRAPHY_TYPES.block_groups) {
+      return MAP_VIEW_GEOGRAPHY_TYPES.block_groups;
+    }
+    if (value === MAP_VIEW_GEOGRAPHY_TYPES.blocks) {
+      return MAP_VIEW_GEOGRAPHY_TYPES.blocks;
+    }
+  }
+  if (isBoundariesCategory(menu1)) {
+    return MAP_VIEW_GEOGRAPHY_TYPES.boundary;
+  }
+  return null;
+}
+
+/**
+ * Map preview: municipal + census tract choropleths, and Boundaries-category layers.
+ */
+export function isMapPreviewSupported(geographyType) {
+  return (
+    geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal ||
+    geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts ||
+    geographyType === MAP_VIEW_GEOGRAPHY_TYPES.boundary
+  );
+}
+
 const ID_LIKE_COLUMN_PATTERN =
   /^(muni(_?id)?|municipal(_?id)?|town(_?id)?|municipality(_?id)?|geo(_?id)?|objectid|gid)$/i;
 
@@ -26,6 +77,24 @@ const NON_MAPPABLE_COLUMN_NAMES = new Set(
     "geometry",
     "geom",
     "logrecno",
+    "county_id",
+    "nbhd_id",
+    "fips_id",
+    "objectid",
+    "id",
+    "rpa_id",
+    "website",
+    "naicscode",
+    "adj_year",
+    "statefp",
+    "countyfp",
+    "tractce",
+    "name",
+    "namelsad",
+    "mtfcc",
+    "funcstat",
+    "intptlat",
+    "intptlon",
     ...MUNICIPAL_MAP_JOIN_COLUMNS,
     ...TRACT_GEO_COLUMNS,
   ].map((name) => name.toLowerCase()),
@@ -35,67 +104,14 @@ const NO_DATA_COLOR = "#E0E0E0";
 const CHOROPLETH_COLORS = ["#EDF8FB", "#B2E2E2", "#66C2A4", "#2CA25F", "#006D2C"];
 
 /**
- * @param {string} tableName
- * @param {string|null|undefined} [geographyHint] Optional `_data_browser.geography` value
- * @returns {"municipal"|"census_tracts"|"block_groups"|null}
- */
-export function detectDatasetGeographyType(tableName, geographyHint = null) {
-  if (isNativeCensusTractBoundaryTable(tableName)) {
-    return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
-  }
-  if (!tableName || typeof tableName !== "string") {
-    return geographyTypeFromHint(geographyHint);
-  }
-
-  if (tableName.endsWith("_m")) return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
-  if (tableName.endsWith("_ct")) return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
-  if (
-    tableName.endsWith("_bg") ||
-    tableName.endsWith("_bg10") ||
-    tableName.endsWith("_bg20")
-  ) {
-    return MAP_VIEW_GEOGRAPHY_TYPES.block_groups;
-  }
-
-  return geographyTypeFromHint(geographyHint);
-}
-
-/**
- * @param {string|null|undefined} geographyHint
- * @returns {"municipal"|"census_tracts"|"block_groups"|null}
- */
-function geographyTypeFromHint(geographyHint) {
-  const hint = String(geographyHint || "").toLowerCase();
-  if (hint.includes("block_group") || hint.includes("block group")) {
-    return MAP_VIEW_GEOGRAPHY_TYPES.block_groups;
-  }
-  if (hint.includes("census_tract") || hint.includes("census tract")) {
-    return MAP_VIEW_GEOGRAPHY_TYPES.census_tracts;
-  }
-  if (hint.includes("municipal")) {
-    return MAP_VIEW_GEOGRAPHY_TYPES.municipal;
-  }
-  return null;
-}
-
-/**
- * @param {string|null|undefined} geographyType
- * @returns {boolean}
- */
-export function isMapPreviewSupported(geographyType) {
-  return (
-    geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal ||
-    geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts
-  );
-}
-
-/**
  * Municipal, census tract, and block group tables can export GeoJSON via the export API.
- * Native tract boundary tables (shape column) use standard geospatial export instead.
+ * Boundaries-category tables use standard geospatial export instead.
+ * Pass `_data_browser.geography` (or an already-resolved geography type) as the second arg.
  */
-export function supportsTabularGeojsonExport(tableName) {
-  if (isNativeCensusTractBoundaryTable(tableName)) return false;
-  const geographyType = detectDatasetGeographyType(tableName);
+export function supportsTabularGeojsonExport(tableName, geography = null, { menu1 = null } = {}) {
+  if (isBoundariesCategory(menu1)) return false;
+  const geographyType = detectDatasetGeographyType(tableName, geography, { menu1 });
+  if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.boundary) return false;
   return (
     geographyType === MAP_VIEW_GEOGRAPHY_TYPES.municipal ||
     geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts ||
@@ -120,7 +136,7 @@ export function resolveTableGeographyColumn(sampleRow) {
 /**
  * Column used to join table rows to map polygons (prefer muni_id / tract ids).
  * @param {object|null} sampleRow
- * @param {"municipal"|"census_tracts"|null} geographyType
+ * @param {"municipal"|"census_tracts"|"boundary"|null} geographyType
  * @param {string|null} [preferredColumn]
  */
 export function resolveMapGeographyColumn(sampleRow, geographyType, preferredColumn = null) {
@@ -147,6 +163,105 @@ function isNumericLike(value) {
   if (typeof value === "boolean") return false;
   const n = Number(String(value).replace(/,/g, "").trim());
   return Number.isFinite(n);
+}
+
+/**
+ * Find the margin-of-error column paired with a base estimate column.
+ * Mirrors DataViewerPage / DatasetHeader pairing (alias + common ACS suffixes).
+ * @param {Array<{name?: string, alias?: string, details?: string}>} columnKeys
+ * @param {string|null|undefined} baseColumnName
+ * @returns {string|null}
+ */
+export function getMarginColumnForBase(columnKeys = [], baseColumnName) {
+  const base = String(baseColumnName || "");
+  if (!base) return null;
+
+  const byName = new Set((columnKeys || []).map((c) => String(c?.name || "")).filter(Boolean));
+  if (!byName.has(base)) return null;
+
+  const byAlias = {};
+  (columnKeys || []).forEach((col) => {
+    const alias = String(col?.alias || "").trim().toLowerCase();
+    if (alias) byAlias[alias] = String(col?.name || "");
+  });
+
+  const normalizeAliasMetric = (text) =>
+    String(text || "")
+      .toLowerCase()
+      .replace(/\s*;\s*(estimate|margin of error)\s*$/i, "")
+      .replace(/\s*,\s*(estimate|margin of error)\s*$/i, "")
+      .trim();
+
+  const getBaseCandidates = (name) => {
+    const candidates = [];
+    const n = String(name || "");
+
+    if (n.endsWith("_mep")) {
+      candidates.push(n.slice(0, -4) + "_p");
+    } else if (/mep$/i.test(n)) {
+      candidates.push(n.slice(0, -3) + "_p");
+    }
+    if (n.endsWith("_mp")) {
+      candidates.push(n.slice(0, -3) + "_p");
+      candidates.push(n.slice(0, -3));
+    }
+    if (n.endsWith("_me")) {
+      candidates.push(n.slice(0, -3));
+    } else if (/[0-9][a-z0-9_]*me$/i.test(n)) {
+      candidates.push(n.slice(0, -2));
+    }
+    if (n.endsWith("_moe")) {
+      candidates.push(n.slice(0, -4));
+    }
+    if (
+      n.endsWith("_m") &&
+      !n.endsWith("_me") &&
+      !n.endsWith("_mp") &&
+      !n.endsWith("_moe") &&
+      !n.endsWith("_mep")
+    ) {
+      candidates.push(n.slice(0, -2));
+    }
+
+    return [...new Set(candidates.filter(Boolean))];
+  };
+
+  const pairs = [];
+  (columnKeys || []).forEach((col) => {
+    const name = String(col?.name || "");
+    if (!name) return;
+
+    const alias = String(col?.alias || "").toLowerCase();
+    const details = String(col?.details || "").toLowerCase();
+    const hintFromMetadata = alias.includes("margin of error") || details.includes("margin of error");
+    const suffixHint =
+      /(?:_mp|_me|_moe|_mep|_m)$/i.test(name) ||
+      /[0-9][a-z0-9_]*me$/i.test(name) ||
+      /[a-z0-9_]mep$/i.test(name);
+    if (!hintFromMetadata && !suffixHint) return;
+
+    let pairedBase = null;
+    if (alias.includes("margin of error")) {
+      const estimateAlias = alias.replace("margin of error", "estimate").replace(/\s+/g, " ").trim();
+      if (byAlias[estimateAlias]) {
+        pairedBase = byAlias[estimateAlias];
+      } else {
+        const normalized = normalizeAliasMetric(alias);
+        const matchedBase = (columnKeys || []).find((candidate) => {
+          const a = String(candidate?.alias || "").toLowerCase();
+          const isEstimate = /\bestimate\b/i.test(a) || (!/\bmargin of error\b/i.test(a) && !!a);
+          return isEstimate && normalizeAliasMetric(a) === normalized;
+        });
+        if (matchedBase?.name) pairedBase = matchedBase.name;
+      }
+    }
+    if (!pairedBase) {
+      pairedBase = getBaseCandidates(name).find((candidate) => byName.has(candidate)) || null;
+    }
+    if (pairedBase === base) pairs.push(name);
+  });
+
+  return pairs[0] || null;
 }
 
 /**
@@ -334,11 +449,11 @@ export function buildValueByGeographyFromFeatures({
     let key = "";
     if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts) {
       const raw =
-        (joinKey && properties[joinKey] != null ? properties[joinKey] : null) ??
         properties.ct20_id ??
         properties.ct10_id ??
+        properties.GEOID ??
         properties.geoid ??
-        properties.GEOID;
+        (joinKey && properties[joinKey] != null ? properties[joinKey] : null);
       key = normalizeTractKey(raw);
     } else {
       const raw =
@@ -531,6 +646,7 @@ export function buildChoroplethScale(values = [], { unit = null } = {}) {
 export function enrichBoundariesWithValues({
   baseGeojson,
   valueByGeography,
+  moeByGeography = null,
   geographyType,
   colorForValue,
   displayNameProperty,
@@ -541,22 +657,44 @@ export function enrichBoundariesWithValues({
 
   const getFeatureKey = (properties = {}) => {
     if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts) {
-      const joinKey = properties.__joinKey;
-      if (joinKey && properties[joinKey] != null) {
-        return normalizeTractKey(properties[joinKey]);
-      }
+      // Prefer real tract ids over whatever __joinKey was inferred (e.g. statefp).
       const raw =
         properties.ct20_id ||
         properties.ct10_id ||
-        properties.GEOID 
+        properties.GEOID ||
+        properties.geoid ||
+        (properties.__joinKey && properties[properties.__joinKey] != null
+          ? properties[properties.__joinKey]
+          : null);
       return normalizeTractKey(raw);
+    }
+    // Boundaries / native shape layers: prefer a per-feature id over a shared parent id.
+    if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.boundary) {
+      const preferred = [
+        "nbhd_id",
+        "GEOID",
+        "geoid",
+        "ct20_id",
+        "ct10_id",
+        "rpa_id",
+        "county_id",
+        "objectid",
+      ];
+      for (const col of preferred) {
+        if (properties[col] != null && properties[col] !== "") {
+          return String(properties[col]);
+        }
+      }
+      const joinKey = properties.__joinKey;
+      if (joinKey && properties[joinKey] != null) return String(properties[joinKey]);
+      return properties.__mapKey != null ? String(properties.__mapKey) : "";
     }
     const joinKey = properties.__joinKey;
     if (joinKey && properties[joinKey] != null) {
       return normalizeMunicipalKey(properties[joinKey]);
     }
     return normalizeMunicipalKey(
-      properties.muni_id ?? properties.municipal ?? properties.NAME,
+      properties.muni_id ?? properties.town_id ?? properties.municipal ?? properties.town ?? properties.NAME,
     );
   };
 
@@ -567,17 +705,19 @@ export function enrichBoundariesWithValues({
     if (geographyType === MAP_VIEW_GEOGRAPHY_TYPES.census_tracts) {
       return (
         properties.ct20_id ||
-        properties.ct10_id 
+        properties.ct10_id
       );
     }
     if (properties.__mapLabel) return String(properties.__mapLabel);
-    const town = properties.municipal || properties.NAME || "";
+    const town = properties.municipal || properties.town || properties.NAME || "";
     if (town) {
       return String(town)
         .toLowerCase()
         .replace(/\b\w/g, (s) => s.toUpperCase());
     }
-    return properties.muni_id != null ? `Muni ${properties.muni_id}` : "Municipality";
+    return properties.muni_id != null || properties.town_id != null
+      ? `Muni ${properties.muni_id ?? properties.town_id}`
+      : "Municipality";
   };
 
   return {
@@ -586,12 +726,15 @@ export function enrichBoundariesWithValues({
       const key = getFeatureKey(feature.properties);
       const value = valueByGeography.get(key);
       const hasValue = Number.isFinite(value);
+      const moeRaw = moeByGeography?.get(key);
+      const moe = Number.isFinite(moeRaw) ? moeRaw : null;
       return {
         ...feature,
         properties: {
           ...feature.properties,
           __mapKey: key,
           __mapValue: hasValue ? value : null,
+          __mapMoe: moe,
           __mapColor: colorForValue(hasValue ? value : null),
           __mapLabel: getDisplayName(feature.properties),
         },
@@ -920,6 +1063,34 @@ export function formatMapValue(value, unit = null) {
   return unit === "%" ? `${formatted}%` : formatted;
 }
 
+/**
+ * Adapt the static / Redux municipal FeatureCollection for map preview joins.
+ * Static asset uses `town` / `town_id`; GIS table uses `municipal` / `muni_id`.
+ */
+export function adaptMunicipalBoundaryGeojson(geojson) {
+  if (!geojson?.features?.length) {
+    return { type: "FeatureCollection", features: [] };
+  }
+  return {
+    type: "FeatureCollection",
+    features: geojson.features.map((feature) => {
+      const props = feature.properties || {};
+      const muniId = props.muni_id ?? props.town_id ?? null;
+      const municipal = props.municipal ?? props.town ?? props.NAME ?? null;
+      return {
+        ...feature,
+        properties: {
+          ...props,
+          muni_id: muniId,
+          municipal,
+          __joinKey: "muni_id",
+          __mapLabel: municipal != null ? String(municipal) : muniId != null ? `Muni ${muniId}` : "Municipality",
+        },
+      };
+    }),
+  };
+}
+
 /** Overlay boundary tables in gisdata.mapc */
 export const GIS_BOUNDARY_LAYERS = {
   municipal: {
@@ -927,35 +1098,11 @@ export const GIS_BOUNDARY_LAYERS = {
     schema: "mapc",
     table: "ma_municipalities",
   },
+  // MAPC region outline uses the static asset (same as community profiles MapBox).
+  // gisdata.mapc.mapc_municipalities_poly is not authorized for the public API token.
   mapcRegion: {
-    database: "gisdata",
-    schema: "mapc",
-    table: "mapc_municipalities_poly",
-  },
-};
-
-/** a temporary fix for census tract boundary datasets that already store polygons in a `shape` column
- * Census tract boundary datasets that already store polygons in a `shape` column
- * Map preview reads shape directly instead of joining.
- */
-export const NATIVE_CENSUS_TRACT_BOUNDARY_TABLES = {
-  census2010_tracts_poly: {
-    database: "gisdata",
-    schema: "mapc",
-    table: "census2010_tracts_poly",
-    joinKey: "ct10_id",
-    idColumn: "ct10_id",
-    attributeColumns: ["ct10_id", "area_sqft", "area_acres"],
-    boundaryLabel: "2010 Census tracts",
-  },
-  census2020_tracts_poly: {
-    database: "gisdata",
-    schema: "mapc",
-    table: "census2020_tracts_poly",
-    joinKey: "ct20_id",
-    idColumn: "GEOID",
-    attributeColumns: ["GEOID", "name", "namelsad", "aland", "awater", "tractce"],
-    boundaryLabel: "2020 Census tracts",
+    source: "static",
+    asset: "mapc-regions",
   },
 };
 
@@ -985,38 +1132,110 @@ function rowValue(row, column) {
   return match != null ? row[match] : undefined;
 }
 
-/**
- * @param {string} tableName
- * @returns {boolean}
- */
-export function isNativeCensusTractBoundaryTable(tableName) {
-  return Boolean(NATIVE_CENSUS_TRACT_BOUNDARY_TABLES[tableName]);
+/** Attribute columns to request (everything except geometry). */
+function attributeColumnsFromNames(columnNames = []) {
+  return [...new Set(
+    (columnNames || [])
+      .map((name) => String(name || "").trim())
+      .filter((name) => name && !OWN_SHAPE_COLUMN_NAMES.has(name.toLowerCase())),
+  )].slice(0, 40);
+}
+
+/** Stable id for feature keys — prefer per-feature ids, never a shared parent id like muni_id. */
+function pickIdColumn(attributeColumns = []) {
+  const exact = (wanted) =>
+    attributeColumns.find((col) => col.toLowerCase() === wanted);
+  // Most-specific first. muni_id is last: neighborhoods / tracts share one muni_id.
+  const preferred = [
+    "geoid",
+    "ct20_id",
+    "ct10_id",
+    "nbhd_id",
+    "rpa_id",
+    "county_id",
+    "objectid",
+    "muni_id",
+  ];
+  for (const want of preferred) {
+    const hit = exact(want);
+    if (hit) return hit;
+  }
+  return (
+    attributeColumns.find((col) => /_id$/i.test(col)) ||
+    exact("id") ||
+    attributeColumns[0] ||
+    "objectid"
+  );
+}
+
+/** Human-readable label — prefer a name-like column, else the id. */
+function pickLabelColumn(attributeColumns = [], idColumn) {
+  const preferredNames = [
+    "municipal",
+    "county",
+    "rpa_name",
+    "neighborhd",
+    "namelsad",
+    "name",
+    "acronym",
+    "town",
+  ];
+  for (const want of preferredNames) {
+    const hit = attributeColumns.find((col) => col.toLowerCase() === want);
+    if (hit) return hit;
+  }
+  const idLower = String(idColumn || "").toLowerCase();
+  const fallback = attributeColumns.find((col) => {
+    const lower = col.toLowerCase();
+    return (
+      lower !== idLower &&
+      lower !== "objectid" &&
+      lower !== "id" &&
+      !/_id$/i.test(col) &&
+      !/^(area_|aland|awater)/i.test(col)
+    );
+  });
+  return fallback || idColumn;
 }
 
 const gisBoundaryCache = new Map();
-const nativeTractBoundaryCache = new Map();
+const nativeBoundaryCache = new Map();
 
 /**
- * Load a native census-tract boundary table (shape column) as WGS84 GeoJSON.
- * @param {{ database?: string, schema?: string, table: string }} params
+ * Load a table’s own `shape` column as WGS84 GeoJSON (no geometry-API join).
+ * Uses column names from the DB / page — no hardcoded table list.
+ *
+ * @param {{
+ *   database: string,
+ *   schema: string,
+ *   table: string,
+ *   columnNames?: string[],
+ *   boundaryLabel?: string|null,
+ * }} params
  */
-export async function fetchNativeCensusTractBoundaryGeojson(params = {}) {
-  const { table } = params;
-  const config = NATIVE_CENSUS_TRACT_BOUNDARY_TABLES[table];
-  if (!config) {
-    throw new Error(`Table "${table}" is not a native census tract boundary table`);
+export async function fetchNativeBoundaryGeojson(params = {}) {
+  const { table, database, schema } = params;
+  if (!table || !database || !schema) {
+    throw new Error("database, schema, and table are required for native boundary fetch");
   }
 
-  const database = params.database || config.database;
-  const schema = params.schema || config.schema;
-  const cacheKey = `${database}.${schema}.${table}`;
-  if (nativeTractBoundaryCache.has(cacheKey)) {
-    return nativeTractBoundaryCache.get(cacheKey);
+  const attributeColumns = attributeColumnsFromNames(params.columnNames);
+  if (!attributeColumns.length) {
+    throw new Error(`No attribute columns available for ${schema}.${table}`);
+  }
+
+  const idColumn = pickIdColumn(attributeColumns);
+  const labelColumn = pickLabelColumn(attributeColumns, idColumn);
+  const boundaryLabel = params.boundaryLabel || "Boundaries";
+  const cacheKey = `${database}.${schema}.${table}:${attributeColumns.join(",")}`;
+
+  if (nativeBoundaryCache.has(cacheKey)) {
+    return nativeBoundaryCache.get(cacheKey);
   }
 
   const pending = (async () => {
     const columns = [
-      ...config.attributeColumns.map(quoteSqlIdentifier),
+      ...attributeColumns.map(quoteSqlIdentifier),
       "sde.ST_AsText(shape) as geom_wkt",
     ].join(",");
     const search = new URLSearchParams({
@@ -1025,14 +1244,14 @@ export async function fetchNativeCensusTractBoundaryGeojson(params = {}) {
       schema,
       table,
       columns,
-      orderByColumn: quoteSqlIdentifier(config.idColumn),
+      orderByColumn: quoteSqlIdentifier(idColumn),
       orderByDirection: "ASC",
       limit: "5000",
     });
 
     const response = await fetch(`/api?${search.toString()}`);
     if (!response.ok) {
-      throw new Error(`Native tract boundary HTTP ${response.status}`);
+      throw new Error(`Native boundary HTTP ${response.status}`);
     }
     const payload = await response.json();
     const rows = payload.rows || [];
@@ -1041,17 +1260,18 @@ export async function fetchNativeCensusTractBoundaryGeojson(params = {}) {
       .map((row) => {
         const geometry = parseWktPolygon(rowValue(row, "geom_wkt"));
         if (!geometry) return null;
-        const id = rowValue(row, config.idColumn);
+        const id = rowValue(row, idColumn);
+        const label = rowValue(row, labelColumn);
         const properties = {
-          __joinKey: config.joinKey,
-          __mapLabel: String(id ?? rowValue(row, "name") ?? rowValue(row, "namelsad") ?? "Census tract"),
+          __joinKey: idColumn,
+          __mapLabel: String(label ?? id ?? "Feature"),
         };
-        config.attributeColumns.forEach((col) => {
+        attributeColumns.forEach((col) => {
           const value = rowValue(row, col);
           if (value != null) properties[col] = value;
         });
-        // Normalize so details panel can label 2020 boundaries via ct20_id.
-        if (config.joinKey === "ct20_id" && properties.GEOID != null && properties.ct20_id == null) {
+        // Geometry API / details panel often look for ct20_id on 2020 tracts.
+        if (properties.GEOID != null && properties.ct20_id == null) {
           properties.ct20_id = properties.GEOID;
         }
         return {
@@ -1069,16 +1289,16 @@ export async function fetchNativeCensusTractBoundaryGeojson(params = {}) {
 
     return {
       featureCollection: { type: "FeatureCollection", features },
-      joinKey: config.joinKey,
-      boundaryLabel: config.boundaryLabel,
+      joinKey: idColumn,
+      boundaryLabel,
     };
   })();
 
-  nativeTractBoundaryCache.set(cacheKey, pending);
+  nativeBoundaryCache.set(cacheKey, pending);
   try {
     return await pending;
   } catch (err) {
-    nativeTractBoundaryCache.delete(cacheKey);
+    nativeBoundaryCache.delete(cacheKey);
     throw err;
   }
 }
@@ -1165,7 +1385,7 @@ export function parseWktPolygon(wkt) {
 }
 
 /**
- * fetch mapc boundary overlays from gisdata
+ * fetch mapc boundary overlays from gisdata (municipal) or static assets (MAPC region)
  */
 export async function fetchGisBoundaryLayer(layerKey) {
   const config = GIS_BOUNDARY_LAYERS[layerKey];
@@ -1178,6 +1398,15 @@ export async function fetchGisBoundaryLayer(layerKey) {
   }
 
   const pending = (async () => {
+    if (config.source === "static" && config.asset === "mapc-regions") {
+      const module = await import("../assets/data/mapc-regions.json");
+      const fc = module.default || module;
+      if (!fc?.features?.length) {
+        throw new Error("MAPC regions asset has no features");
+      }
+      return fc;
+    }
+
     const search = new URLSearchParams({
       token: import.meta.env.VITE_MAPC_API_TOKEN,
       database: config.database,

--- a/src/utils/datasetMapPreview.js
+++ b/src/utils/datasetMapPreview.js
@@ -1115,9 +1115,6 @@ export const GIS_BOUNDARY_LAYERS = {
   },
 };
 
-/** @deprecated Use NATIVE_BOUNDARY_TABLES */
-export const NATIVE_CENSUS_TRACT_BOUNDARY_TABLES = NATIVE_BOUNDARY_TABLES;
-
 /**
  * Quote mixed-case Postgres identifiers (e.g. GEOID) so they are not folded to lowercase.
  * @param {string} column


### PR DESCRIPTION
### Map UI / metadata
- removed** the map header title.
- footer is one line: Classification · Source · Years · link to the table title (opens map in a new tab, strips embed).
- details: variable + value on one row; long labels wrap; left-aligned.
- long metric titles wrap in a narrower space; values stay on one line (Details + embed tooltip).
### Embed map 
- Keep: map, legend, N arrow, boundary toggles, Source/Years/Link footer
- hide: Variable panel, Details side panel, Download GeoJSON.
- feature details via hover Mapbox popup.
- legend scales with the map (container queries); layout fills the iframe (App--embed-map).
- embed size: Small removed for map embeds (Medium / Large / Custom remain).
### category= boundaries map preview join key fixes
-use GEOID / tract ids so tract maps don’t select the whole state via statefp.
-use nbhd_id before muni_id so neighborhood boundaries don’t all select together.